### PR TITLE
Fix portability.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,11 +5,13 @@ _aaaa.mm.dd_
 
 ### New features
 * Possibility to import a TPGGraph and its programs with the File::TPGGraphDotImporter class.
+* New Data::Hash class providing a portable hash mechanism in replacement of std::hash.
 
 ### Changes
 * Renaming the Exporter namespace into File.
 
 ### Bug fix
+* Training and mutation process were not portable on multiple OSes and compilers because of the diverse implementations of std::hash.
 
 
 ## Release version 0.0.0

--- a/gegelatilib/include/data/hash.h
+++ b/gegelatilib/include/data/hash.h
@@ -100,17 +100,6 @@ namespace Data {
 	};
 
 	template<>
-	struct Hash<long double> {
-		using argument_type = long double;
-		using result_type = size_t;
-		_NODISCARD size_t
-
-			operator()(const long double _Keyval) const noexcept {
-			return _Hash_representation(_Keyval == 0.0L ? 0.0L : _Keyval); // map -0 to 0
-		}
-	};
-
-	template<>
 	struct Hash<nullptr_t> {
 		using argument_type = nullptr_t;
 		using result_type = size_t;

--- a/gegelatilib/include/data/hash.h
+++ b/gegelatilib/include/data/hash.h
@@ -1,0 +1,127 @@
+/**
+* Code from MSVC 19 implementation of std::hash.
+* Published under license Apache-2.0 WITH LLVM-exception
+*/
+#ifndef HASH_H
+#define HASH_H
+
+#include <cstddef>
+#include <type_traits>
+
+namespace Data {
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#ifndef _NODISCARD
+#define _NODISCARD [[nodiscard]]
+#endif
+
+#if defined(_WIN64) || defined(__x86_64__)
+	inline constexpr size_t _FNV_offset_basis = 14695981039346656037ULL;
+	inline constexpr size_t _FNV_prime = 1099511628211ULL;
+#else // defined(_WIN64)
+	inline constexpr size_t _FNV_offset_basis = 2166136261U;
+	inline constexpr size_t _FNV_prime = 16777619U;
+#endif // defined(_WIN64)
+
+	_NODISCARD inline size_t _Fnv1a_append_bytes(size_t _Val, const unsigned char* const _First,
+		const size_t _Count) noexcept { // accumulate range [_First, _First + _Count) into partial FNV-1a hash _Val
+		for (size_t _Idx = 0; _Idx < _Count; ++_Idx) {
+			_Val ^= static_cast<size_t>(_First[_Idx]);
+			_Val *= _FNV_prime;
+		}
+
+		return _Val;
+	}
+
+	template <class _Kty>
+	_NODISCARD size_t _Fnv1a_append_value(
+		const size_t _Val, const _Kty& _Keyval) noexcept { // accumulate _Keyval into partial FNV-1a hash _Val
+		static_assert(std::is_trivial_v<_Kty>, "Only trivial types can be directly hashed.");
+		return _Fnv1a_append_bytes(_Val, &reinterpret_cast<const unsigned char&>(_Keyval), sizeof(_Kty));
+	}
+
+	// FUNCTION TEMPLATE _Hash_representation
+	template <class _Kty>
+	_NODISCARD size_t _Hash_representation(const _Kty& _Keyval) noexcept { // bitwise hashes the representation of a key
+		return _Fnv1a_append_value(_FNV_offset_basis, _Keyval);
+	}
+
+	// STRUCT TEMPLATE _Conditionally_enabled_hash
+	template<class _Kty>
+	struct hash;
+
+	template<class _Kty, bool _Enabled>
+	struct _Conditionally_enabled_hash { // conditionally enabled hash base
+		using argument_type = _Kty;
+		using result_type = size_t;
+
+		_NODISCARD size_t
+
+			operator()(const _Kty& _Keyval) const
+			noexcept(noexcept(hash<_Kty>::_Do_hash(_Keyval))) /* strengthened */ {
+			return hash<_Kty>::_Do_hash(_Keyval);
+		}
+	};
+
+	// STRUCT TEMPLATE hash
+	template<class _Kty>
+	struct hash
+		: _Conditionally_enabled_hash<_Kty,
+		!std::is_const_v < _Kty> && !
+		std::is_volatile_v <_Kty> && (std::is_enum_v<_Kty>
+			|| std::is_integral_v <_Kty> || std::is_pointer_v <_Kty>)> {
+		// hash functor primary template (handles enums, integrals, and pointers)
+		static size_t _Do_hash(const _Kty& _Keyval) noexcept {
+			return _Hash_representation(_Keyval);
+		}
+	};
+
+	template<>
+	struct hash<float> {
+		using argument_type = float;
+		using result_type = size_t;
+		_NODISCARD size_t
+
+			operator()(const float _Keyval) const noexcept {
+			return _Hash_representation(_Keyval == 0.0F ? 0.0F : _Keyval); // map -0 to 0
+		}
+	};
+
+	template<>
+	struct hash<double> {
+		using argument_type = double;
+		using result_type = size_t;
+		_NODISCARD size_t
+
+			operator()(const double _Keyval) const noexcept {
+			return _Hash_representation(_Keyval == 0.0 ? 0.0 : _Keyval); // map -0 to 0
+		}
+	};
+
+	template<>
+	struct hash<long double> {
+		using argument_type = long double;
+		using result_type = size_t;
+		_NODISCARD size_t
+
+			operator()(const long double _Keyval) const noexcept {
+			return _Hash_representation(_Keyval == 0.0L ? 0.0L : _Keyval); // map -0 to 0
+		}
+	};
+
+	template<>
+	struct hash<nullptr_t> {
+		using argument_type = nullptr_t;
+		using result_type = size_t;
+		_NODISCARD size_t
+
+			operator()(nullptr_t) const noexcept {
+			void* _Null{};
+			return _Hash_representation(_Null);
+		}
+	};
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+}
+
+#endif 

--- a/gegelatilib/include/data/hash.h
+++ b/gegelatilib/include/data/hash.h
@@ -49,7 +49,7 @@ namespace Data {
 
 	// STRUCT TEMPLATE _Conditionally_enabled_hash
 	template<class _Kty>
-	struct hash;
+	struct Hash;
 
 	template<class _Kty, bool _Enabled>
 	struct _Conditionally_enabled_hash { // conditionally enabled hash base
@@ -59,14 +59,14 @@ namespace Data {
 		_NODISCARD size_t
 
 			operator()(const _Kty& _Keyval) const
-			noexcept(noexcept(hash<_Kty>::_Do_hash(_Keyval))) /* strengthened */ {
-			return hash<_Kty>::_Do_hash(_Keyval);
+			noexcept(noexcept(Hash<_Kty>::_Do_hash(_Keyval))) /* strengthened */ {
+			return Hash<_Kty>::_Do_hash(_Keyval);
 		}
 	};
 
 	// STRUCT TEMPLATE hash
 	template<class _Kty>
-	struct hash
+	struct Hash
 		: _Conditionally_enabled_hash<_Kty,
 		!std::is_const_v < _Kty> && !
 		std::is_volatile_v <_Kty> && (std::is_enum_v<_Kty>
@@ -78,7 +78,7 @@ namespace Data {
 	};
 
 	template<>
-	struct hash<float> {
+	struct Hash<float> {
 		using argument_type = float;
 		using result_type = size_t;
 		_NODISCARD size_t
@@ -89,7 +89,7 @@ namespace Data {
 	};
 
 	template<>
-	struct hash<double> {
+	struct Hash<double> {
 		using argument_type = double;
 		using result_type = size_t;
 		_NODISCARD size_t
@@ -100,7 +100,7 @@ namespace Data {
 	};
 
 	template<>
-	struct hash<long double> {
+	struct Hash<long double> {
 		using argument_type = long double;
 		using result_type = size_t;
 		_NODISCARD size_t
@@ -111,7 +111,7 @@ namespace Data {
 	};
 
 	template<>
-	struct hash<nullptr_t> {
+	struct Hash<nullptr_t> {
 		using argument_type = nullptr_t;
 		using result_type = size_t;
 		_NODISCARD size_t

--- a/gegelatilib/include/dataHandlers/primitiveTypeArray.h
+++ b/gegelatilib/include/dataHandlers/primitiveTypeArray.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <typeinfo>
 
+#include "data/hash.h"
 #include "dataHandler.h"
 
 namespace DataHandlers {
@@ -166,10 +167,10 @@ namespace DataHandlers {
 	inline size_t PrimitiveTypeArray<T>::updateHash() const
 	{
 		// reset
-		this->cachedHash = std::hash<size_t>()(this->id);
+		this->cachedHash = Data::hash<size_t>()(this->id);
 
 		// hasher
-		std::hash<T> hasher;
+		Data::hash<T> hasher;
 
 		for (PrimitiveType<T> dataElement : this->data) {
 			// Rotate by 1 because otherwise, xor is comutative.

--- a/gegelatilib/include/dataHandlers/primitiveTypeArray.h
+++ b/gegelatilib/include/dataHandlers/primitiveTypeArray.h
@@ -167,10 +167,10 @@ namespace DataHandlers {
 	inline size_t PrimitiveTypeArray<T>::updateHash() const
 	{
 		// reset
-		this->cachedHash = Data::hash<size_t>()(this->id);
+		this->cachedHash = Data::Hash<size_t>()(this->id);
 
 		// hasher
-		Data::hash<T> hasher;
+		Data::Hash<T> hasher;
 
 		for (PrimitiveType<T> dataElement : this->data) {
 			// Rotate by 1 because otherwise, xor is comutative.

--- a/gegelatilib/include/gegelati.h
+++ b/gegelatilib/include/gegelati.h
@@ -1,6 +1,6 @@
 /**
 * \file gegelati.h
-* \brief Helper file gathering all headers from the GEGELATI lib to ease their 
+* \brief Helper file gathering all headers from the GEGELATI lib to ease their
 * inclusion in apps.
 */
 #ifndef GEGELATI_H
@@ -8,6 +8,7 @@
 
 #include <dataHandlers/dataHandler.h>  
 #include <dataHandlers/primitiveTypeArray.h>
+#include <data/hash.h>
 
 #include <file/tpgGraphDotExporter.h>
 

--- a/gegelatilib/include/learn/classificationLearningAgent.h
+++ b/gegelatilib/include/learn/classificationLearningAgent.h
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <stdexcept>
 
+#include <data/hash.h>
 #include "learn/evaluationResult.h"
 #include "learn/classificationEvaluationResult.h"
 #include "learn/learningAgent.h"
@@ -94,7 +95,7 @@ namespace Learn {
 		// Evaluate nbIteration times
 		for (auto i = 0; i < this->params.nbIterationsPerPolicyEvaluation; i++) {
 			// Compute a Hash
-			std::hash<uint64_t> hasher;
+			Data::hash<uint64_t> hasher;
 			uint64_t hash = hasher(generationNumber) ^ hasher(i);
 
 			// Reset the learning Environment

--- a/gegelatilib/include/learn/classificationLearningAgent.h
+++ b/gegelatilib/include/learn/classificationLearningAgent.h
@@ -95,7 +95,7 @@ namespace Learn {
 		// Evaluate nbIteration times
 		for (auto i = 0; i < this->params.nbIterationsPerPolicyEvaluation; i++) {
 			// Compute a Hash
-			Data::hash<uint64_t> hasher;
+			Data::Hash<uint64_t> hasher;
 			uint64_t hash = hasher(generationNumber) ^ hasher(i);
 
 			// Reset the learning Environment

--- a/gegelatilib/include/mutator/deterministicRandom.h
+++ b/gegelatilib/include/mutator/deterministicRandom.h
@@ -5,6 +5,7 @@
 
 #define _NODISCARD [[nodiscard]]
 
+// For unsigned int 
 namespace Mutator {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
@@ -240,8 +241,8 @@ namespace Mutator {
 	public:
 		// _RNG_REQUIRE_INTTYPE(uniform_int_distribution, _Ty); // From visual Removed
 
-		using _Mybase     = uniform_int<_Ty>;
-		using _Mypbase    = typename _Mybase::param_type;
+		using _Mybase = uniform_int<_Ty>;
+		using _Mypbase = typename _Mybase::param_type;
 		using result_type = typename _Mybase::result_type;
 
 		struct param_type : public _Mypbase { // parameter package
@@ -276,4 +277,168 @@ namespace Mutator {
 	}
 #endif
 }
+#include <istream>
+// For Double
+namespace Mutator {
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#define _NRAND(eng, resty) (std::generate_canonical<resty, static_cast<size_t>(-1)>(eng))
+
+	// CLASS TEMPLATE uniform_real
+	template <class _Ty = double>
+	class uniform_real { // uniform real distribution
+	public:
+		using result_type = _Ty;
+
+		struct param_type { // parameter package
+			using distribution_type = uniform_real;
+
+			explicit param_type(_Ty _Min0 = _Ty{ 0 }, _Ty _Max0 = _Ty{ 1 }) {
+				_Init(_Min0, _Max0);
+			}
+
+			_NODISCARD bool operator==(const param_type& _Right) const {
+				return _Min == _Right._Min && _Max == _Right._Max;
+			}
+
+			_NODISCARD bool operator!=(const param_type& _Right) const {
+				return !(*this == _Right);
+			}
+
+			_NODISCARD result_type a() const {
+				return _Min;
+			}
+
+			_NODISCARD result_type b() const {
+				return _Max;
+			}
+
+			void _Init(_Ty _Min0, _Ty _Max0) { // set internal state
+				// From Visual : removed
+				// _STL_ASSERT(_Min0 <= _Max0 && (0 <= _Min0 || _Max0 <= _Min0 + (std::numeric_limits<_Ty>::max)()),
+				//	"invalid min and max arguments for uniform_real");
+				_Min = _Min0;
+				_Max = _Max0;
+			}
+
+			result_type _Min;
+			result_type _Max;
+		};
+
+		explicit uniform_real(_Ty _Min0 = _Ty{ 0 }, _Ty _Max0 = _Ty{ 1 }) : _Par(_Min0, _Max0) {}
+
+		explicit uniform_real(const param_type& _Par0) : _Par(_Par0) {}
+
+		_NODISCARD result_type a() const {
+			return _Par.a();
+		}
+
+		_NODISCARD result_type b() const {
+			return _Par.b();
+		}
+
+		_NODISCARD param_type param() const {
+			return _Par;
+		}
+
+		void param(const param_type& _Par0) { // set parameter package
+			_Par = _Par0;
+		}
+
+		_NODISCARD result_type(min)() const {
+			return _Par._Min;
+		}
+
+		_NODISCARD result_type(max)() const {
+			return _Par._Max;
+		}
+
+		void reset() { // clear internal state
+		}
+
+		template <class _Engine>
+		_NODISCARD result_type operator()(_Engine& _Eng) const {
+			return _Eval(_Eng, _Par);
+		}
+
+		template <class _Engine>
+		_NODISCARD result_type operator()(_Engine& _Eng, const param_type& _Par0) const {
+			return _Eval(_Eng, _Par0);
+		}
+
+		template <class _Elem, class _Traits>
+		std::basic_istream<_Elem, _Traits>& _Read(std::basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
+			_Ty _Min0;
+			_Ty _Max0;
+			_In(_Istr, _Min0);
+			_In(_Istr, _Max0);
+			_Par._Init(_Min0, _Max0);
+			return _Istr;
+		}
+
+		template <class _Elem, class _Traits>
+		std::basic_ostream<_Elem, _Traits>& _Write(std::basic_ostream<_Elem, _Traits>& _Ostr) const { // write state to _Ostr
+			_Out(_Ostr, _Par._Min);
+			_Out(_Ostr, _Par._Max);
+			return _Ostr;
+		}
+
+	private:
+		template <class _Engine>
+		result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
+			return _NRAND(_Eng, _Ty) * (_Par0._Max - _Par0._Min) + _Par0._Min;
+		}
+
+		param_type _Par;
+	};
+
+	template <class _Elem, class _Traits, class _Ty>
+	std::basic_istream<_Elem, _Traits>& operator>>(std::basic_istream<_Elem, _Traits>& _Istr,
+		uniform_real<_Ty>& _Dist) { // read state from _Istr
+		return _Dist._Read(_Istr);
+	}
+
+	template <class _Elem, class _Traits, class _Ty>
+	std::basic_ostream<_Elem, _Traits>& operator<<(std::basic_ostream<_Elem, _Traits>& _Ostr,
+		const uniform_real<_Ty>& _Dist) { // write state to _Ostr
+		return _Dist._Write(_Ostr);
+	}
+
+
+	// CLASS TEMPLATE uniform_real_distribution
+	template <class _Ty = double>
+	class uniform_real_distribution : public uniform_real<_Ty> { // uniform real distribution
+	public:
+		//_RNG_REQUIRE_REALTYPE(uniform_real_distribution, _Ty);
+
+		using _Mybase = uniform_real<_Ty>;
+		using _Mypbase = typename _Mybase::param_type;
+		using result_type = typename _Mybase::result_type;
+
+		struct param_type : public _Mypbase { // parameter package
+			using distribution_type = uniform_real_distribution;
+
+			explicit param_type(_Ty _Min0 = _Ty{ 0 }, _Ty _Max0 = _Ty{ 1 }) : _Mypbase(_Min0, _Max0) {}
+
+			param_type(const _Mypbase& _Right) : _Mypbase(_Right) {}
+		};
+
+		explicit uniform_real_distribution(_Ty _Min0 = _Ty{ 0 }, _Ty _Max0 = _Ty{ 1 }) : _Mybase(_Min0, _Max0) {}
+
+		explicit uniform_real_distribution(const param_type& _Par0) : _Mybase(_Par0) {}
+	};
+
+	template <class _Ty>
+	_NODISCARD bool operator==(const uniform_real_distribution<_Ty>& _Left, const uniform_real_distribution<_Ty>& _Right) {
+		return _Left.param() == _Right.param();
+	}
+
+	template <class _Ty>
+	_NODISCARD bool operator!=(const uniform_real_distribution<_Ty>& _Left, const uniform_real_distribution<_Ty>& _Right) {
+		return !(_Left == _Right);
+	}
+#endif
+}
+
 #endif 
+

--- a/gegelatilib/src/learn/learningAgent.cpp
+++ b/gegelatilib/src/learn/learningAgent.cpp
@@ -1,5 +1,6 @@
 #include <inttypes.h>
 
+#include "data/hash.h"
 #include "tpg/tpgExecutionEngine.h"
 #include "mutator/rng.h"
 #include "mutator/tpgMutator.h"
@@ -40,7 +41,7 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateRoot(TPG:
 	// Evaluate nbIteration times
 	for (auto i = 0; i < this->params.nbIterationsPerPolicyEvaluation; i++) {
 		// Compute a Hash
-		std::hash<uint64_t> hasher;
+		Data::hash<uint64_t> hasher;
 		uint64_t hash = hasher(generationNumber) ^ hasher(i);
 
 		// Reset the learning Environment

--- a/gegelatilib/src/learn/learningAgent.cpp
+++ b/gegelatilib/src/learn/learningAgent.cpp
@@ -41,7 +41,7 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateRoot(TPG:
 	// Evaluate nbIteration times
 	for (auto i = 0; i < this->params.nbIterationsPerPolicyEvaluation; i++) {
 		// Compute a Hash
-		Data::hash<uint64_t> hasher;
+		Data::Hash<uint64_t> hasher;
 		uint64_t hash = hasher(generationNumber) ^ hasher(i);
 
 		// Reset the learning Environment

--- a/gegelatilib/src/mutator/rng.cpp
+++ b/gegelatilib/src/mutator/rng.cpp
@@ -13,6 +13,6 @@ uint64_t Mutator::RNG::getUnsignedInt64(uint64_t min, uint64_t max)
 
 double Mutator::RNG::getDouble(double min, double max)
 {
-	std::uniform_real_distribution<double> distribution(min, max);
+	Mutator::uniform_real_distribution<double> distribution(min, max);
 	return distribution(engine);
 }

--- a/test/dataHashTest.cpp
+++ b/test/dataHashTest.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include "data/hash.h"
+
+TEST(DataHashTest, HashInt) {
+
+	ASSERT_EQ(Data::Hash<int>()(1337), 10617510125527791323);
+	ASSERT_EQ(Data::Hash<unsigned int>()(666), 11188042650382073989);
+	ASSERT_EQ(Data::Hash<uint64_t>()(UINT64_MAX), 10157053723145373757);
+}
+
+
+TEST(DataHashTest, HashDouble) {
+	ASSERT_EQ(Data::Hash<double>()(12.00), 12123769577132206109);
+	ASSERT_EQ(Data::Hash<float>()((float)3.14), 2246715419936742613);
+}
+
+TEST(DataHashTest, HashNullptr) {
+	nullptr_t t = NULL;
+	ASSERT_EQ(Data::Hash<nullptr_t>()(t), 12161962213042174405);
+}

--- a/test/learn/stickGameWithOpponent.cpp
+++ b/test/learn/stickGameWithOpponent.cpp
@@ -37,8 +37,7 @@ void StickGameWithOpponent::doAction(uint64_t actionID)
 
 		// Random player's turn
 		if (currentState > 0) {
-			std::uniform_int_distribution<int> distribution(1, std::min(currentState, 3));
-			currentState -= distribution(engine);
+			currentState -= (int)rng.getUnsignedInt64(1, std::min(currentState, 3));
 			this->remainingSticks.setDataAt(typeid(PrimitiveType<int>), 0, currentState);
 			if (currentState == 0) {
 				this->win = true;
@@ -51,7 +50,7 @@ void StickGameWithOpponent::reset(size_t seed, Learn::LearningMode mode)
 {
 	// Create seed from seed and mode
 	size_t hash_seed = Data::hash<size_t>()(seed) ^ Data::hash<Learn::LearningMode>()(mode);
-	this->engine.seed(hash_seed);
+	this->rng.setSeed(hash_seed);
 	this->remainingSticks.setDataAt(typeid(PrimitiveType<int>), 0, 21);
 	this->win = false;
 	this->forbiddenMove = false;

--- a/test/learn/stickGameWithOpponent.cpp
+++ b/test/learn/stickGameWithOpponent.cpp
@@ -50,7 +50,7 @@ void StickGameWithOpponent::doAction(uint64_t actionID)
 void StickGameWithOpponent::reset(size_t seed, Learn::LearningMode mode)
 {
 	// Create seed from seed and mode
-	size_t hash_seed = std::hash<size_t>()(seed) ^ std::hash<Learn::LearningMode>()(mode);
+	size_t hash_seed = Data::hash<size_t>()(seed) ^ Data::hash<Learn::LearningMode>()(mode);
 	this->engine.seed(hash_seed);
 	this->remainingSticks.setDataAt(typeid(PrimitiveType<int>), 0, 21);
 	this->win = false;

--- a/test/learn/stickGameWithOpponent.cpp
+++ b/test/learn/stickGameWithOpponent.cpp
@@ -49,7 +49,7 @@ void StickGameWithOpponent::doAction(uint64_t actionID)
 void StickGameWithOpponent::reset(size_t seed, Learn::LearningMode mode)
 {
 	// Create seed from seed and mode
-	size_t hash_seed = Data::hash<size_t>()(seed) ^ Data::hash<Learn::LearningMode>()(mode);
+	size_t hash_seed = Data::Hash<size_t>()(seed) ^ Data::Hash<Learn::LearningMode>()(mode);
 	this->rng.setSeed(hash_seed);
 	this->remainingSticks.setDataAt(typeid(PrimitiveType<int>), 0, 21);
 	this->win = false;

--- a/test/learn/stickGameWithOpponent.h
+++ b/test/learn/stickGameWithOpponent.h
@@ -3,6 +3,7 @@
 
 #include <random>
 
+#include "mutator/rng.h"
 #include "dataHandlers/primitiveTypeArray.h"
 #include "learn/learningEnvironment.h"
 
@@ -24,7 +25,7 @@ protected:
 	bool forbiddenMove;
 
 	/// Randomness control
-	std::mt19937_64 engine;
+	Mutator::RNG rng;
 
 public:
 

--- a/test/learningAgentTest.cpp
+++ b/test/learningAgentTest.cpp
@@ -32,6 +32,7 @@ protected:
 		params.mutation.tpg.pProgramMutation = 0.2;
 		params.mutation.tpg.pEdgeDestinationChange = 0.1;
 		params.mutation.tpg.pEdgeDestinationIsAction = 0.5;
+		params.mutation.tpg.maxOutgoingEdges = 4;
 		params.mutation.prog.pAdd = 0.5;
 		params.mutation.prog.pDelete = 0.5;
 		params.mutation.prog.pMutate = 1.0;

--- a/test/learningAgentTest.cpp
+++ b/test/learningAgentTest.cpp
@@ -189,6 +189,33 @@ TEST_F(LearningAgentTest, Train) {
 	ASSERT_NO_THROW(la.train(alt, true)) << "Using the boolean reference to stop the training should not fail.";
 }
 
+// Similat to previous test, but verifications of graphs properties are here to
+// ensure the result of the training is identical on all OSes and Compilers.
+TEST_F(LearningAgentTest, TrainPortability) {
+	params.archiveSize = 50;
+	params.archivingProbability = 0.5;
+	params.maxNbActionsPerEval = 11;
+	params.nbIterationsPerPolicyEvaluation = 5;
+	params.ratioDeletedRoots = 0.2;
+	params.nbGenerations = 20;
+	params.mutation.tpg.nbRoots = 30;
+
+	Learn::LearningAgent la(le, set, params);
+
+	la.init();
+	bool alt = false;
+	la.train(alt, false);
+
+	// It is quite unlikely that two different TPGs after 20 generations
+	// end up with the same number of vertices, roots, edges and calls to
+	// the RNG without being identical.
+	TPG::TPGGraph& tpg = la.getTPGGraph();
+	ASSERT_EQ(tpg.getNbVertices(), 30) << "Graph does not have the expected determinst characteristics.";
+	ASSERT_EQ(tpg.getNbRootVertices(), 24) << "Graph does not have the expected determinst characteristics.";
+	ASSERT_EQ(tpg.getEdges().size(), 101) << "Graph does not have the expected determinst characteristics.";
+	ASSERT_EQ(la.getRNG().getUnsignedInt64(0, UINT64_MAX), 12618987376045473466) << "Graph does not have the expected determinst characteristics.";
+}
+
 TEST_F(LearningAgentTest, KeepBestPolicy) {
 	params.archiveSize = 50;
 	params.archivingProbability = 0.5;
@@ -515,6 +542,8 @@ TEST_F(ParallelLearningAgentTest, TrainParallelDeterminism) {
 
 	// Check number of vertex in graphs
 	// Non-zero to avoid false positive.
+	// These checks guarantee determinism between sequential and parallel version on a given platform.
+	// They do not guarantee portability between compilers and OS
 	ASSERT_GT(la.getTPGGraph().getNbVertices(), 0) << "Number of vertex in the trained graph should not be 0.";
 	ASSERT_EQ(la.getTPGGraph().getNbVertices(), pla.getTPGGraph().getNbVertices()) << "LearningAgent and ParallelLearning agent result in different TPGGraphs.";
 }


### PR DESCRIPTION
Applications, including those in test and from gegelati/gegelati apps, were producing different training behavior on Linux and on Windows.

This was caused by vendor-specific implementation of the standard std::hash function.
Problem solved by using our own Data::Hash class, adapted from MSVC19 std::hash implementation (released under license Apache-2.0 WITH LLVM-exception).
