### PR TITLE
moving maxNbThreads from PLA to LA to enable PLA to use LA's trainOne…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ _2020.06.12_
 
 ### Changes
 * LearningAgent now receives the number of threads and registers from the LearningParameter.
+* maxNbThreads is now a variable of learningAgent allowing to have a more generic trainOneGeneration method
 
 ### Bug fix
 * Fix non-determinism issue in ClassificationLearningAgent.

--- a/gegelatilib/include/learn/learningAgent.h
+++ b/gegelatilib/include/learn/learningAgent.h
@@ -94,6 +94,8 @@ namespace Learn {
 		/// Random Number Generator for this Learning Agent
 		Mutator::RNG rng;
 
+        /// Control the maximum number of threads when running in parallel.
+        uint64_t maxNbThreads;
 	public:
 		/**
 		* \brief Constructor for LearningAgent.
@@ -108,7 +110,8 @@ namespace Learn {
 			env(iSet, le.getDataSources(), p.nbRegisters),
 			tpg(this->env),
 			params{ p },
-			archive(p.archiveSize, p.archivingProbability)
+			archive(p.archiveSize, p.archivingProbability),
+			maxNbThreads(1)
 		{
 			// override the number of actions from the parameters.
 			this->params.mutation.tpg.nbActions = this->learningEnvironment.getNbActions();

--- a/gegelatilib/include/learn/learningAgent.h
+++ b/gegelatilib/include/learn/learningAgent.h
@@ -95,7 +95,7 @@ namespace Learn {
 		Mutator::RNG rng;
 
         /// Control the maximum number of threads when running in parallel.
-        uint64_t maxNbThreads;
+        uint64_t maxNbThreads = 1;
 	public:
 		/**
 		* \brief Constructor for LearningAgent.
@@ -110,8 +110,7 @@ namespace Learn {
 			env(iSet, le.getDataSources(), p.nbRegisters),
 			tpg(this->env),
 			params{ p },
-			archive(p.archiveSize, p.archivingProbability),
-			maxNbThreads(1)
+			archive(p.archiveSize, p.archivingProbability)
 		{
 			// override the number of actions from the parameters.
 			this->params.mutation.tpg.nbActions = this->learningEnvironment.getNbActions();

--- a/gegelatilib/include/learn/parallelLearningAgent.h
+++ b/gegelatilib/include/learn/parallelLearningAgent.h
@@ -50,98 +50,99 @@
 #include "learn/learningAgent.h"
 
 namespace Learn {
-	/**
-	* \brief  Class used to control the learning steps of a TPGGraph within
-	* a given LearningEnvironment, with parallel executions for speedup
-	* purposes.
-	*
-	* This class is intented to replace the default LearningAgent soon.
-	*
-	* Because of parallelism, determinism of the LearningProcess could easiliy
-	* be lost, but this implementation must remain deterministic at all costs.
-	*/
-	class ParallelLearningAgent : public LearningAgent {
-	protected:
-		/// Control the maximum number of threads when running in parallel.
-		const uint64_t maxNbThreads;
+    /**
+    * \brief  Class used to control the learning steps of a TPGGraph within
+    * a given LearningEnvironment, with parallel executions for speedup
+    * purposes.
+    *
+    * This class is intented to replace the default LearningAgent soon.
+    *
+    * Because of parallelism, determinism of the LearningProcess could easiliy
+    * be lost, but this implementation must remain deterministic at all costs.
+    */
+    class ParallelLearningAgent : public LearningAgent {
+    protected:
+        /**
+        * \brief Method for evaluating all roots with parallelism.
+        *
+        * \param[in] generationNumber the integer number of the current generation.
+        * \param[in] mode the LearningMode to use during the policy evaluation.
+        * \param[in] results Map to store the resulting score of evaluated roots.
+        */
+        void evaluateAllRootsInParallel(uint64_t generationNumber, LearningMode mode,
+                                        std::multimap<std::shared_ptr<EvaluationResult>, const TPG::TPGVertex *> &results);
 
-		/**
-		* \brief Method for evaluating all roots with parallelism.
-		*
-		* \param[in] generationNumber the integer number of the current generation.
-		* \param[in] mode the LearningMode to use during the policy evaluation.
-		* \param[in] results Map to store the resulting score of evaluated roots.
-		*/
-		void evaluateAllRootsInParallel(uint64_t generationNumber, LearningMode mode, std::multimap<std::shared_ptr<EvaluationResult>, const TPG::TPGVertex*>& results);
+        /**
+        * \brief Function implementing the behavior of slave threads during
+        * parallel evaluation of roots.
+        *
+        * \param[in] generationNumber the integer number of the current generation.
+        * \param[in] mode the LearningMode to use during the policy evaluation.
+        * \param[in,out] rootsToProcess Ordered list of root TPGVertex to
+        * process, stored as a pair with an id filling the archiveMap.
+        * \param[in] rootsToProcessMutex Mutex protecting the rootsToProcess
+        * \param[in] resultsPerRootMap Map to store the resulting score of evaluated roots.
+        * \param[in] resultsPerRootMapMutex Mutex protecting the results.
+        * \param[in] archiveSeeds Seed values for the archiving process of each root.
+        * \param[in,out] archiveMap Map storing the exhaustiveArchive to be merged.
+        * \param[in] archiveMapMutex Mutex protecting the archiveMap.
+        */
+        void slaveEvalRootThread(uint64_t generationNumber, LearningMode mode,
+                                 std::queue<std::pair<uint64_t, const TPG::TPGVertex *>> &rootsToProcess,
+                                 std::mutex &rootsToProcessMutex,
+                                 std::map<uint64_t, std::pair<std::shared_ptr<EvaluationResult>, const TPG::TPGVertex *>> &resultsPerRootMap,
+                                 std::mutex &resultsPerRootMapMutex,
+                                 std::map<uint64_t, size_t> &archiveSeeds,
+                                 std::map<uint64_t, Archive *> &archiveMap, std::mutex &archiveMapMutex);
 
-		/**
-		* \brief Function implementing the behavior of slave threads during
-		* parallel evaluation of roots.
-		*
-		* \param[in] generationNumber the integer number of the current generation.
-		* \param[in] mode the LearningMode to use during the policy evaluation.
-		* \param[in,out] rootsToProcess Ordered list of root TPGVertex to
-		* process, stored as a pair with an id filling the archiveMap.
-		* \param[in] rootsToProcessMutex Mutex protecting the rootsToProcess
-		* \param[in] resultsPerRootMap Map to store the resulting score of evaluated roots.
-		* \param[in] resultsPerRootMapMutex Mutex protecting the results.
-		* \param[in] archiveSeeds Seed values for the archiving process of each root.
-		* \param[in,out] archiveMap Map storing the exhaustiveArchive to be merged.
-		* \param[in] archiveMapMutex Mutex protecting the archiveMap.
-		*/
-		void slaveEvalRootThread(uint64_t generationNumber, LearningMode mode,
-			std::queue<std::pair<uint64_t, const TPG::TPGVertex*>>& rootsToProcess, std::mutex& rootsToProcessMutex,
-			std::map<uint64_t, std::pair<std::shared_ptr<EvaluationResult>, const TPG::TPGVertex*>>& resultsPerRootMap, std::mutex& resultsPerRootMapMutex,
-			std::map<uint64_t, size_t>& archiveSeeds,
-			std::map<uint64_t, Archive*>& archiveMap, std::mutex& archiveMapMutex);
+        /**
+        * \brief Method to merge several Archive created in parallel
+        * threads.
+        *
+        * The purpose of this method is to merhe several Archive
+        * into the archive attribute of this ParallelLearningAgent. This
+        * method is the key to obtain deterministic Archive even in a parallel
+        * context.
+        *
+        * \param[in,out] archiveMap Map storing the Archive to be merged.
+        */
+        void mergeArchiveMap(std::map<uint64_t, Archive *> &archiveMap);
 
-		/**
-		* \brief Method to merge several Archive created in parallel
-		* threads.
-		*
-		* The purpose of this method is to merhe several Archive
-		* into the archive attribute of this ParallelLearningAgent. This
-		* method is the key to obtain deterministic Archive even in a parallel
-		* context.
-		*
-		* \param[in,out] archiveMap Map storing the Archive to be merged.
-		*/
-		void mergeArchiveMap(std::map<uint64_t, Archive*>& archiveMap);
+    public:
+        /**
+        * \brief Constructor for ParallelLearningAgent.
+        *
+        * Based on default constructor of LearningAgent
+        *
+        * \param[in] le The LearningEnvironment for the TPG.
+        * \param[in] iSet Set of Instruction used to compose Programs in the
+        *            learning process.
+        * \param[in] p The LearningParameters for the LearningAgent.
+        */
+        ParallelLearningAgent(LearningEnvironment &le, const Instructions::Set &iSet, const LearningParameters &p) :
+                LearningAgent(le, iSet, p) {
+            // overriding the maxNbThreads that basic LA defined to 1
+            maxNbThreads = p.nbThreads;
+        };
 
-	public:
-		/**
-		* \brief Constructor for ParallelLearningAgent.
-		*
-		* Based on default constructor of LearningAgent
-		*
-		* \param[in] le The LearningEnvironment for the TPG.
-		* \param[in] iSet Set of Instruction used to compose Programs in the
-		*            learning process.
-		* \param[in] p The LearningParameters for the LearningAgent.
-		*/
-		ParallelLearningAgent(LearningEnvironment& le, const Instructions::Set& iSet, const LearningParameters& p) :
-			LearningAgent(le, iSet, p), maxNbThreads{ p.nbThreads } {};
-
-		/**
-		* \brief Evaluate all root TPGVertex of the TPGGraph.
-		*
-		* **Replaces the function from the base class LearningAgent.**
-		*
-		* This method must always the same results as the evaluateAllRoots for
-		* a sequential execution. The Archive should also be updated in the
-		* exact same manner.
-		*
-		* This method calls the evaluateRoot method for every root TPGVertex
-		* of the TPGGraph. The method returns a sorted map associating each root
-		* vertex to its average score, in ascending order or score.
-		*
-		* \param[in] generationNumber the integer number of the current generation.
-		* \param[in] mode the LearningMode to use during the policy evaluation.
-		*/
-		std::multimap<std::shared_ptr<EvaluationResult>, const TPG::TPGVertex*> evaluateAllRoots(uint64_t generationNumber, LearningMode mode) override;
-
-		/// Inherited from LearningAgent
-		void trainOneGeneration(uint64_t generationNumber) override;
-	};
+        /**
+        * \brief Evaluate all root TPGVertex of the TPGGraph.
+        *
+        * **Replaces the function from the base class LearningAgent.**
+        *
+        * This method must always the same results as the evaluateAllRoots for
+        * a sequential execution. The Archive should also be updated in the
+        * exact same manner.
+        *
+        * This method calls the evaluateRoot method for every root TPGVertex
+        * of the TPGGraph. The method returns a sorted map associating each root
+        * vertex to its average score, in ascending order or score.
+        *
+        * \param[in] generationNumber the integer number of the current generation.
+        * \param[in] mode the LearningMode to use during the policy evaluation.
+        */
+        std::multimap<std::shared_ptr<EvaluationResult>, const TPG::TPGVertex *>
+        evaluateAllRoots(uint64_t generationNumber, LearningMode mode) override;
+    };
 }
 #endif 

--- a/gegelatilib/src/learn/learningAgent.cpp
+++ b/gegelatilib/src/learn/learningAgent.cpp
@@ -156,7 +156,7 @@ std::multimap< std::shared_ptr<Learn::EvaluationResult>, const TPG::TPGVertex*> 
 void Learn::LearningAgent::trainOneGeneration(uint64_t generationNumber)
 {
 	// Populate Sequentially
-	Mutator::TPGMutator::populateTPG(this->tpg, this->archive, this->params.mutation, this->rng, 1);
+	Mutator::TPGMutator::populateTPG(this->tpg, this->archive, this->params.mutation, this->rng, maxNbThreads);
 
 	// Evaluate
 	auto results = this->evaluateAllRoots(generationNumber, LearningMode::TRAINING);

--- a/gegelatilib/src/learn/parallelLearningAgent.cpp
+++ b/gegelatilib/src/learn/parallelLearningAgent.cpp
@@ -233,18 +233,3 @@ void Learn::ParallelLearningAgent::evaluateAllRootsInParallel(uint64_t generatio
 	// Merge the archives
 	this->mergeArchiveMap(archiveMap);
 }
-
-void Learn::ParallelLearningAgent::trainOneGeneration(uint64_t generationNumber)
-{
-	// Populate Sequentially
-	Mutator::TPGMutator::populateTPG(this->tpg, this->archive, this->params.mutation, this->rng, this->maxNbThreads);
-
-	// Evaluate
-	auto results = this->evaluateAllRoots(generationNumber, LearningMode::TRAINING);
-
-	// Remove worst performing roots
-	decimateWorstRoots(results);
-
-	// Update the best (code duplicate in LearningAgent)
-	this->updateEvaluationRecords(results);
-}


### PR DESCRIPTION
This branch only centralizes a method thanks to a parameter (maxNbThreads) that is given to the LearningAgent