### PR TITLE
(Releng) Fix memory leak when __cxa_demangle is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Thumbs.db
 # CMake generated files
 **/cmake-build-debug/
 **/cmake-build-release/
+**/cmake-build-release-coverage/

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # GEGELATI Changelog
 
+## Release version x.y.z
+_yyyy.mm.dd_
+
+### New features
+
+### Changes
+
+### Bug fix
+* Fix memory leak when demangling type name in GNU environment.
+
+
 ## Release version 0.6.0
 _2021.06.02_
 

--- a/gegelatilib/include/data/array2DWrapper.h
+++ b/gegelatilib/include/data/array2DWrapper.h
@@ -38,6 +38,7 @@
 
 #include "data/arrayWrapper.h"
 #include "data/dataHandler.h"
+#include "data/demangle.h"
 
 namespace Data {
 

--- a/gegelatilib/include/data/arrayWrapper.h
+++ b/gegelatilib/include/data/arrayWrapper.h
@@ -45,9 +45,9 @@
 #include <typeinfo>
 
 #include "data/constant.h"
+#include "data/dataHandler.h"
+#include "data/demangle.h"
 #include "data/hash.h"
-#include "dataHandler.h"
-#include "demangle.h"
 
 namespace Data {
 

--- a/gegelatilib/include/data/arrayWrapper.h
+++ b/gegelatilib/include/data/arrayWrapper.h
@@ -53,9 +53,10 @@
 #define DEMANGLE_TYPEID_NAME(name) name
 #elif __GNUC__
 #include <cxxabi.h>
+std::string demangle(const char* name);
 /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name)                                             \
-    abi::__cxa_demangle(name, nullptr, nullptr, nullptr)
+    demangle(name).c_str()
 #else
 #error Unsupported compiler (yet): Check need for name demangling of typeid.name().
 #endif

--- a/gegelatilib/include/data/arrayWrapper.h
+++ b/gegelatilib/include/data/arrayWrapper.h
@@ -47,19 +47,8 @@
 #include "data/constant.h"
 #include "data/hash.h"
 #include "dataHandler.h"
+#include "demangle.h"
 
-#ifdef _MSC_VER
-/// Macro for getting type name in human readable format.
-#define DEMANGLE_TYPEID_NAME(name) name
-#elif __GNUC__
-#include <cxxabi.h>
-std::string demangle(const char* name);
-/// Macro for getting type name in human readable format.
-#define DEMANGLE_TYPEID_NAME(name)                                             \
-    demangle(name).c_str()
-#else
-#error Unsupported compiler (yet): Check need for name demangling of typeid.name().
-#endif
 
 namespace Data {
 

--- a/gegelatilib/include/data/arrayWrapper.h
+++ b/gegelatilib/include/data/arrayWrapper.h
@@ -49,7 +49,6 @@
 #include "dataHandler.h"
 #include "demangle.h"
 
-
 namespace Data {
 
     /**

--- a/gegelatilib/include/data/demangle.h
+++ b/gegelatilib/include/data/demangle.h
@@ -18,7 +18,7 @@ namespace Data {
      */
     std::string demangle(const char* name);
 /// Macro for getting type name in human readable format.
-#define DEMANGLE_TYPEID_NAME(name) demangle(name).c_str()
+#define DEMANGLE_TYPEID_NAME(name) Data::demangle(name).c_str()
 #else
 #error Unsupported compiler (yet): Check need for name demangling of typeid.name().
 #endif

--- a/gegelatilib/include/data/demangle.h
+++ b/gegelatilib/include/data/demangle.h
@@ -3,12 +3,13 @@
 
 #include <string>
 
-namespace Data {
+
 #ifdef _MSC_VER
 /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name) name
 #elif __GNUC__
 #include <cxxabi.h>
+namespace Data {
     /**
      * \brief Function calling abi::__cxa_demangle to return the type name in a
      * human readable format.
@@ -16,12 +17,12 @@ namespace Data {
      * \param[in] name const char* of the type to demangle.
      * \return demangle type of name in a std::string.
      */
-    ::std::string demangle(const char* name);
+    std::string demangle(const char* name);
+} // namespace Data
 /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name) Data::demangle(name).c_str()
 #else
 #error Unsupported compiler (yet): Check need for name demangling of typeid.name().
 #endif
-} // namespace Data
 
 #endif // DEMANGLE_H

--- a/gegelatilib/include/data/demangle.h
+++ b/gegelatilib/include/data/demangle.h
@@ -10,8 +10,7 @@
 #include <cxxabi.h>
 std::string demangle(const char* name);
 /// Macro for getting type name in human readable format.
-#define DEMANGLE_TYPEID_NAME(name)                                             \
-    demangle(name).c_str()
+#define DEMANGLE_TYPEID_NAME(name) demangle(name).c_str()
 #else
 #error Unsupported compiler (yet): Check need for name demangling of typeid.name().
 #endif

--- a/gegelatilib/include/data/demangle.h
+++ b/gegelatilib/include/data/demangle.h
@@ -16,7 +16,7 @@ namespace Data {
      * \param[in] name const char* of the type to demangle.
      * \return demangle type of name in a std::string.
      */
-    std::string demangle(const char* name);
+    ::std::string demangle(const char* name);
 /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name) Data::demangle(name).c_str()
 #else

--- a/gegelatilib/include/data/demangle.h
+++ b/gegelatilib/include/data/demangle.h
@@ -3,7 +3,6 @@
 
 #include <string>
 
-
 #ifdef _MSC_VER
 /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name) name
@@ -19,7 +18,7 @@ namespace Data {
      */
     std::string demangle(const char* name);
 } // namespace Data
-/// Macro for getting type name in human readable format.
+  /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name) Data::demangle(name).c_str()
 #else
 #error Unsupported compiler (yet): Check need for name demangling of typeid.name().

--- a/gegelatilib/include/data/demangle.h
+++ b/gegelatilib/include/data/demangle.h
@@ -1,0 +1,19 @@
+#ifndef GEGELATI_DEMANGLE_H
+#define GEGELATI_DEMANGLE_H
+
+#include <string>
+
+#ifdef _MSC_VER
+/// Macro for getting type name in human readable format.
+#define DEMANGLE_TYPEID_NAME(name) name
+#elif __GNUC__
+#include <cxxabi.h>
+std::string demangle(const char* name);
+/// Macro for getting type name in human readable format.
+#define DEMANGLE_TYPEID_NAME(name)                                             \
+    demangle(name).c_str()
+#else
+#error Unsupported compiler (yet): Check need for name demangling of typeid.name().
+#endif
+
+#endif // GEGELATI_DEMANGLE_H

--- a/gegelatilib/include/data/demangle.h
+++ b/gegelatilib/include/data/demangle.h
@@ -1,18 +1,27 @@
-#ifndef GEGELATI_DEMANGLE_H
-#define GEGELATI_DEMANGLE_H
+#ifndef DEMANGLE_H
+#define DEMANGLE_H
 
 #include <string>
 
+namespace Data {
 #ifdef _MSC_VER
 /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name) name
 #elif __GNUC__
 #include <cxxabi.h>
-std::string demangle(const char* name);
+    /**
+     * \brief Function calling abi::__cxa_demangle to return the type name in a
+     * human readable format.
+     *
+     * \param[in] name const char* of the type to demangle.
+     * \return demangle type of name in a std::string.
+     */
+    std::string demangle(const char* name);
 /// Macro for getting type name in human readable format.
 #define DEMANGLE_TYPEID_NAME(name) demangle(name).c_str()
 #else
 #error Unsupported compiler (yet): Check need for name demangling of typeid.name().
 #endif
+} // namespace Data
 
-#endif // GEGELATI_DEMANGLE_H
+#endif // DEMANGLE_H

--- a/gegelatilib/src/data/demangle.cpp
+++ b/gegelatilib/src/data/demangle.cpp
@@ -11,9 +11,7 @@ std::string demangle(const char* name)
         free(demangleValue);
     }
     else {
-        throw std::runtime_error("Error while trying to demangle the value. "
-                                 "Return code of abi::__cxa_demangle is " +
-                                 std::to_string(status));
+        throw std::runtime_error("Error while trying to demangle a value.");
     }
     return result;
 }

--- a/gegelatilib/src/data/demangle.cpp
+++ b/gegelatilib/src/data/demangle.cpp
@@ -1,0 +1,20 @@
+#include "data/arrayWrapper.h"
+
+#ifdef __GNUC__
+std::string demangle(const char* name)
+{
+    int status = -4;
+    char* demangleValue = abi::__cxa_demangle(name, nullptr, nullptr, &status);
+    std::string result;
+    if (status == 0) {
+        result = std::string{demangleValue};
+        free(demangleValue);
+    }
+    else {
+        throw std::runtime_error("Error while trying to demangle the value. "
+                                 "Return code of abi::__cxa_demangle is " +
+                                 std::to_string(status));
+    }
+    return result;
+}
+#endif

--- a/gegelatilib/src/data/demangle.cpp
+++ b/gegelatilib/src/data/demangle.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 
 #ifdef __GNUC__
-std::string demangle(const char* name)
+std::string Data::demangle(const char* name)
 {
     int status = -4;
     char* demangleValue = abi::__cxa_demangle(name, nullptr, nullptr, &status);

--- a/gegelatilib/src/data/demangle.cpp
+++ b/gegelatilib/src/data/demangle.cpp
@@ -1,4 +1,5 @@
-#include "data/arrayWrapper.h"
+#include "data/demangle.h"
+#include <stdexcept>
 
 #ifdef __GNUC__
 std::string demangle(const char* name)

--- a/gegelatilib/src/data/demangle.cpp
+++ b/gegelatilib/src/data/demangle.cpp
@@ -1,5 +1,6 @@
-#include "data/demangle.h"
 #include <stdexcept>
+
+#include "data/demangle.h"
 
 #ifdef __GNUC__
 std::string Data::demangle(const char* name)

--- a/test/demangleTest.cpp
+++ b/test/demangleTest.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#ifdef __GNUC__
+#include "data/arrayWrapper.h"
+
+TEST(DemangleTest, demangleTypeDouble)
+{
+    std::string demangled;
+    const std::type_info& type = typeid(double);
+    ASSERT_NO_THROW(demangled = demangle(type.name()));
+
+    ASSERT_EQ(demangled, std::string("double"));
+
+    ASSERT_EQ(strcmp(DEMANGLE_TYPEID_NAME(type.name()), demangled.c_str()), 0);
+}
+
+TEST(DemangleTest, demangleFail)
+{
+    const char* toDemangle = "gegelati";
+    const std::type_info& type = typeid(double);
+    ASSERT_THROW(demangle(toDemangle), std::runtime_error);
+
+    ASSERT_THROW(DEMANGLE_TYPEID_NAME(toDemangle), std::runtime_error);
+}
+#endif

--- a/test/demangleTest.cpp
+++ b/test/demangleTest.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #ifdef __GNUC__
-#include "data/arrayWrapper.h"
+#include "data/demangle.h"
 
 TEST(DemangleTest, demangleTypeDouble)
 {
@@ -17,7 +17,7 @@ TEST(DemangleTest, demangleTypeDouble)
 TEST(DemangleTest, demangleFail)
 {
     const char* toDemangle = "gegelati";
-    const std::type_info& type = typeid(double);
+
     ASSERT_THROW(demangle(toDemangle), std::runtime_error);
 
     ASSERT_THROW(DEMANGLE_TYPEID_NAME(toDemangle), std::runtime_error);

--- a/test/demangleTest.cpp
+++ b/test/demangleTest.cpp
@@ -7,7 +7,7 @@ TEST(DemangleTest, demangleTypeDouble)
 {
     std::string demangled;
     const std::type_info& type = typeid(double);
-    ASSERT_NO_THROW(demangled = demangle(type.name()))
+    ASSERT_NO_THROW(demangled = Data::demangle(type.name()))
         << "Error can't demangle the primitive type double.";
 
     ASSERT_EQ(demangled, std::string("double"))
@@ -23,7 +23,7 @@ TEST(DemangleTest, demangleFail)
 {
     const char* toDemangle = "gegelati";
 
-    ASSERT_THROW(demangle(toDemangle), std::runtime_error)
+    ASSERT_THROW(Data::demangle(toDemangle), std::runtime_error)
         << "Error the function should be able to demangle the type "
            "\"gegelati\"";
 

--- a/test/demangleTest.cpp
+++ b/test/demangleTest.cpp
@@ -7,19 +7,28 @@ TEST(DemangleTest, demangleTypeDouble)
 {
     std::string demangled;
     const std::type_info& type = typeid(double);
-    ASSERT_NO_THROW(demangled = demangle(type.name()));
+    ASSERT_NO_THROW(demangled = demangle(type.name()))
+        << "Error can't demangle the primitive type double.";
 
-    ASSERT_EQ(demangled, std::string("double"));
+    ASSERT_EQ(demangled, std::string("double"))
+        << " Error the type demangle is not equal to \"double\"";
 
-    ASSERT_EQ(strcmp(DEMANGLE_TYPEID_NAME(type.name()), demangled.c_str()), 0);
+    ASSERT_EQ(strcmp(DEMANGLE_TYPEID_NAME(type.name()), demangled.c_str()), 0)
+        << "Error the return type of the macro DEMANGLE_TYPEID_NAME is not "
+           "equal to a const char* of the function demangle(const "
+           "std::type_info&)";
 }
 
 TEST(DemangleTest, demangleFail)
 {
     const char* toDemangle = "gegelati";
 
-    ASSERT_THROW(demangle(toDemangle), std::runtime_error);
+    ASSERT_THROW(demangle(toDemangle), std::runtime_error)
+        << "Error the function should be able to demangle the type "
+           "\"gegelati\"";
 
-    ASSERT_THROW(DEMANGLE_TYPEID_NAME(toDemangle), std::runtime_error);
+    ASSERT_THROW(DEMANGLE_TYPEID_NAME(toDemangle), std::runtime_error)
+        << "Error the macro DEMANGLE_TYPEID_NAME should be able to demangle "
+           "the type \"gegelati\"";
 }
 #endif


### PR DESCRIPTION
Add a function _demangle_ that creates a **std::string** from the return value of __cxa_demangle. Then the return value is free.