### PR TITLE
Fix arm64 build

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ _aaaa.mm.dd_
 
 ### Bug fix
 * Change google test repo config. Branch name is now `main` instead of `develop`.
+* Fix determinism issue with ARM 64-bit architecture in `Data::Hash`. Determinism still not provided on non 64bit architectures (X86, ARM, or others). 
 
 
 ## Release version 1.0.0 - Amamaretto version/flavor

--- a/gegelatilib/include/data/hash.h
+++ b/gegelatilib/include/data/hash.h
@@ -51,7 +51,7 @@ namespace Data {
 #define _NODISCARD [[nodiscard]]
 #endif
 
-#if defined(_WIN64) || defined(__x86_64__)
+#if defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__)
     inline constexpr size_t _FNV_offset_basis = 14695981039346656037ULL;
     inline constexpr size_t _FNV_prime = 1099511628211ULL;
 #else  // defined(_WIN64)

--- a/test/lambdaInstructionTest.cpp
+++ b/test/lambdaInstructionTest.cpp
@@ -154,7 +154,7 @@ TEST(LambdaInstructionsTest, ExecuteArray)
     arguments.emplace_back(
         std::make_shared<Data::UntypedSharedPtr::Model<const double[]>>(
             new double[3]{arrayB}));
-    ASSERT_EQ(instruction->execute(arguments), 23.54)
+    ASSERT_DOUBLE_EQ(instruction->execute(arguments), 23.54)
         << "Result returned by the instruction is not as expected.";
 }
 


### PR DESCRIPTION
Fix unit test & determinism for ARM 64bit architectures.
This fix was tested on an NVidia Tegra tx2 board with an ARM A57 processor.