### PR TITLE
(Log) Add cycle detection LA logger

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # GEGELATI Changelog
 
+## Release version x.y.z
+_yyyy.mm.dd_
+
+### New features
+* Add a `Log::CycleDetectionLALogger` for detecting directed cycles in TPG graphs. Using this logger, the detection is automatically at each generation right after populating the TPG with new vertices. In case a cycle is detected, a message is printed in `std::cerr`.
+
+### Changes
+
+### Bug fix
+
+
 ## Release version 1.2.0 - Cantutuccini flavor
 _2022.08.31_
 

--- a/gegelatilib/include/gegelati.h
+++ b/gegelatilib/include/gegelati.h
@@ -85,6 +85,7 @@
 #include <learn/classificationLearningAgent.h>
 #include <learn/classificationLearningEnvironment.h>
 
+#include <log/cycleDetectionLALogger.h>
 #include <log/laBasicLogger.h>
 #include <log/laLogger.h>
 #include <log/laPolicyStatsLogger.h>

--- a/gegelatilib/include/log/cycleDetectionLALogger.h
+++ b/gegelatilib/include/log/cycleDetectionLALogger.h
@@ -1,0 +1,106 @@
+#include "laLogger.h"
+
+namespace Log {
+
+    /**
+     * \brief Detector for connected cycles in TPGs
+     *
+     * This utility class implement a depth-first search algorithm for detecting
+     * the presence of directed cyclic paths in TPGs.
+     */
+    class CycleDetectionLALogger : public LALogger
+    {
+      public:
+        /**
+         * \brief Same constructor as LALogger. Default output is cerr.
+         *
+         * \param[in] la LearningAgent whose TPG will be analyzed by the
+         * CycleDetectionLALogger.
+         * \param[in] out The output stream the logger will send
+         * elements to.
+         */
+        explicit CycleDetectionLALogger(Learn::LearningAgent& la,
+                                        std::ostream& out = std::cerr)
+            : LALogger(la, out)
+        {
+        }
+
+        /**
+         * Inherited via LALogger
+         *
+         * \brief Does nothing in this logger.
+         */
+        virtual void logHeader() override
+        {
+            // nothing to log
+        }
+
+        /**
+         * Inherited via LALogger.
+         *
+         * \brief Does nothing in this logger.
+         */
+        virtual void logNewGeneration(uint64_t& generationNumber) override
+        {
+            // nothing to log
+        }
+
+        /**
+         * Inherited via LALogger.
+         *
+         * \brief Checks the presence of directed cyclic path in the TPG. Loggs
+         * an output if there is one.
+         */
+        virtual void logAfterPopulateTPG() override;
+
+        /**
+         * Inherited via LaLogger.
+         *
+         * \brief Does nothing in this logger.
+         *
+         * \param[in] results scores of the evaluation.
+         */
+        virtual void logAfterEvaluate(
+            std::multimap<std::shared_ptr<Learn::EvaluationResult>,
+                          const TPG::TPGVertex*>& results) override
+        {
+            // nothing to log
+        }
+
+        /**
+         * Inherited via LaLogger.
+         *
+         * \brief Does nothing in this logger.
+         */
+        virtual void logAfterDecimate() override{
+            // nothing to log
+        };
+
+        /**
+         * Inherited via LaLogger.
+         *
+         * \brief Logs the min, avg and max score of the generation.
+         *
+         * If doValidation is true, no eval results are logged so that
+         * the logger can only show validation results.
+         *
+         * \param[in] results scores of the validation.
+         */
+        virtual void logAfterValidate(
+            std::multimap<std::shared_ptr<Learn::EvaluationResult>,
+                          const TPG::TPGVertex*>& results) override
+        {
+            // nothing to log
+        }
+
+        /**
+         * Inherited via LaLogger
+         *
+         * \brief Does nothing in this logger.
+         */
+        virtual void logEndOfTraining() override
+        {
+            // nothing to log
+        }
+    };
+}; // namespace Log

--- a/gegelatilib/include/log/cycleDetectionLALogger.h
+++ b/gegelatilib/include/log/cycleDetectionLALogger.h
@@ -37,20 +37,14 @@ namespace Log {
          *
          * \brief Does nothing in this logger.
          */
-        virtual void logHeader() override
-        {
-            // nothing to log
-        }
+        virtual void logHeader() override;
 
         /**
          * Inherited via LALogger.
          *
          * \brief Does nothing in this logger.
          */
-        virtual void logNewGeneration(uint64_t& generationNumber) override
-        {
-            // nothing to log
-        }
+        virtual void logNewGeneration(uint64_t& generationNumber) override;
 
         /**
          * Inherited via LALogger.
@@ -69,19 +63,14 @@ namespace Log {
          */
         virtual void logAfterEvaluate(
             std::multimap<std::shared_ptr<Learn::EvaluationResult>,
-                          const TPG::TPGVertex*>& results) override
-        {
-            // nothing to log
-        }
+                          const TPG::TPGVertex*>& results) override;
 
         /**
          * Inherited via LaLogger.
          *
          * \brief Does nothing in this logger.
          */
-        virtual void logAfterDecimate() override{
-            // nothing to log
-        };
+        virtual void logAfterDecimate() override;
 
         /**
          * Inherited via LaLogger.
@@ -95,19 +84,12 @@ namespace Log {
          */
         virtual void logAfterValidate(
             std::multimap<std::shared_ptr<Learn::EvaluationResult>,
-                          const TPG::TPGVertex*>& results) override
-        {
-            // nothing to log
-        }
-
+                          const TPG::TPGVertex*>& results) override;
         /**
          * Inherited via LaLogger
          *
          * \brief Does nothing in this logger.
          */
-        virtual void logEndOfTraining() override
-        {
-            // nothing to log
-        }
+        virtual void logEndOfTraining() override;
     };
 }; // namespace Log

--- a/gegelatilib/include/log/cycleDetectionLALogger.h
+++ b/gegelatilib/include/log/cycleDetectionLALogger.h
@@ -10,6 +10,10 @@ namespace Log {
      */
     class CycleDetectionLALogger : public LALogger
     {
+      private:
+        /// Control whether a message is printed when no loop is detected.
+        bool logOnSuccess;
+
       public:
         /**
          * \brief Same constructor as LALogger. Default output is cerr.
@@ -18,10 +22,13 @@ namespace Log {
          * CycleDetectionLALogger.
          * \param[in] out The output stream the logger will send
          * elements to.
+         * \param[in] logOnSuccess When true, the logger will log the absence of
+         * cycles.
          */
         explicit CycleDetectionLALogger(Learn::LearningAgent& la,
-                                        std::ostream& out = std::cerr)
-            : LALogger(la, out)
+                                        std::ostream& out = std::cerr,
+                                        bool logOnSuccess = false)
+            : LALogger(la, out), logOnSuccess(logOnSuccess)
         {
         }
 

--- a/gegelatilib/include/tpg/tpgVertex.h
+++ b/gegelatilib/include/tpg/tpgVertex.h
@@ -57,7 +57,7 @@ namespace TPG {
         const std::list<TPGEdge*>& getIncomingEdges() const;
 
         /**
-         * \brief Get a const reference to incoming edges of this TPGVertex.
+         * \brief Get a const reference to outgoing edges of this TPGVertex.
          */
         const std::list<TPGEdge*>& getOutgoingEdges() const;
 

--- a/gegelatilib/src/log/cycleDetectionLALogger.cpp
+++ b/gegelatilib/src/log/cycleDetectionLALogger.cpp
@@ -5,6 +5,16 @@
 #include "learn/learningAgent.h"
 #include "log/cycleDetectionLALogger.h"
 
+void Log::CycleDetectionLALogger::logHeader()
+{
+    // nothing to log
+}
+
+void Log::CycleDetectionLALogger::logNewGeneration(uint64_t& generationNumber)
+{
+    // nothing to log
+}
+
 void Log::CycleDetectionLALogger::logAfterPopulateTPG()
 {
     // Do a Depth First Search of the TPG from all roots.
@@ -73,4 +83,28 @@ void Log::CycleDetectionLALogger::logAfterPopulateTPG()
     if (this->logOnSuccess) {
         *this << "No cycle detected in this TPG.";
     }
+}
+
+void Log::CycleDetectionLALogger::logAfterEvaluate(
+    std::multimap<std::shared_ptr<Learn::EvaluationResult>,
+                  const TPG::TPGVertex*>& results)
+{
+    // nothing to log
+}
+
+void Log::CycleDetectionLALogger::logAfterDecimate()
+{
+    // nothing to log
+}
+
+void Log::CycleDetectionLALogger::logAfterValidate(
+    std::multimap<std::shared_ptr<Learn::EvaluationResult>,
+                  const TPG::TPGVertex*>& results)
+{
+    // nothing to log
+}
+
+void Log::CycleDetectionLALogger::logEndOfTraining()
+{
+    // nothing to log
 }

--- a/gegelatilib/src/log/cycleDetectionLALogger.cpp
+++ b/gegelatilib/src/log/cycleDetectionLALogger.cpp
@@ -1,5 +1,73 @@
+#include <deque>
+#include <set>
+#include <vector>
+
+#include "learn/learningAgent.h"
 #include "log/cycleDetectionLALogger.h"
 
 void Log::CycleDetectionLALogger::logAfterPopulateTPG()
 {
+    // Do a Depth First Search of the TPG from all roots.
+    std::set<const TPG::TPGVertex*> visitedVertices;
+    std::vector<const TPG::TPGVertex*> lifoToVisit;
+    std::vector<const TPG::TPGVertex*> currentPath;
+
+    // Add all roots to the set of vertex to visit
+    const auto tpg = this->learningAgent.getTPGGraph();
+    auto roots = tpg->getRootVertices();
+    std::copy(roots.begin(), roots.end(), std::back_inserter(lifoToVisit));
+
+    // Iterate on the stack
+    while (!lifoToVisit.empty()) {
+        // Pop first vertex
+        const TPG::TPGVertex* vertex = lifoToVisit.back();
+        lifoToVisit.pop_back();
+
+        // If vertex is null pointer, this means we need to unstack a vertex
+        // from the current path.
+        if (vertex == nullptr) {
+            currentPath.pop_back();
+            // Go to the next iteration of the DFS while loop.
+            continue;
+        }
+
+        // Mark vertex as visited
+        visitedVertices.insert(vertex);
+
+        // Scan outgoing edges
+        const TPG::TPGTeam* team = dynamic_cast<const TPG::TPGTeam*>(vertex);
+        if (team != nullptr) {
+            // Push vertex in path
+            currentPath.push_back(vertex);
+
+            // Push a nullptr to lifo to visit. When this pointer is
+            // encountered, the vertex will be popped from the current path.
+            lifoToVisit.push_back(nullptr);
+
+            for (auto edge : team->getOutgoingEdges()) {
+                // Check if the destination is in the path
+                if (std::find(currentPath.begin(), currentPath.end(),
+                              edge->getDestination()) != currentPath.end()) {
+                    // A cycle was detected !
+                    *this << "A cycle was detected in the TPG.";
+
+                    // Early termination
+                    return;
+                }
+
+                // Put the destination on the lifo
+                lifoToVisit.push_back(edge->getDestination());
+            }
+        }
+    }
+
+    // Check that all vertices were visited.
+    if (visitedVertices.size() != tpg->getNbVertices()) {
+        // Not all vertices were visited: A connected sub-graph was not visited.
+        // This happens when a connected sub-graph has no root, which indicates
+        // that the subgraph has a cycle.
+        *this << "A cycle was detected in the TPG.";
+    }
+
+    // If this point of the algorithm is reached, no cycle were detected
 }

--- a/gegelatilib/src/log/cycleDetectionLALogger.cpp
+++ b/gegelatilib/src/log/cycleDetectionLALogger.cpp
@@ -1,0 +1,5 @@
+#include "log/cycleDetectionLALogger.h"
+
+void Log::CycleDetectionLALogger::logAfterPopulateTPG()
+{
+}

--- a/gegelatilib/src/log/cycleDetectionLALogger.cpp
+++ b/gegelatilib/src/log/cycleDetectionLALogger.cpp
@@ -70,4 +70,7 @@ void Log::CycleDetectionLALogger::logAfterPopulateTPG()
     }
 
     // If this point of the algorithm is reached, no cycle were detected
+    if (this->logOnSuccess) {
+        *this << "No cycle detected in this TPG.";
+    }
 }

--- a/test/cycleDetectionLALoggerTest.cpp
+++ b/test/cycleDetectionLALoggerTest.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include "instructions/addPrimitiveType.h"
+#include "instructions/multByConstant.h"
+#include "learn/learningAgent.h"
+#include "learn/stickGameWithOpponent.h"
+
+#include "log/cycleDetectionLALogger.h"
+
+class CycleDetectionLoggerTest : public ::testing::Test
+{
+  protected:
+    Instructions::Set set;
+
+    std::multimap<std::shared_ptr<Learn::EvaluationResult>,
+                  const TPG::TPGVertex*>
+        results;
+
+    StickGameWithOpponent le;
+    Learn::LearningParameters params;
+    Learn::LearningAgent* la;
+
+    void SetUp() override
+    {
+        // Proba as in Kelly's paper
+        params.mutation.tpg.maxInitOutgoingEdges = 3;
+        params.mutation.prog.maxProgramSize = 96;
+        params.mutation.tpg.nbRoots = 15;
+        params.mutation.tpg.pEdgeDeletion = 0.7;
+        params.mutation.tpg.pEdgeAddition = 0.7;
+        params.mutation.tpg.pProgramMutation = 0.2;
+        params.mutation.tpg.pEdgeDestinationChange = 0.1;
+        params.mutation.tpg.pEdgeDestinationIsAction = 0.5;
+        params.mutation.tpg.maxOutgoingEdges = 4;
+        params.mutation.prog.pAdd = 0.5;
+        params.mutation.prog.pDelete = 0.5;
+        params.mutation.prog.pMutate = 1.0;
+        params.mutation.prog.pSwap = 1.0;
+        params.mutation.prog.minConstValue = 0;
+        params.mutation.prog.maxConstValue = 3;
+        params.nbProgramConstant = 0;
+
+        params.archiveSize = 50;
+        params.archivingProbability = 0.5;
+        params.maxNbActionsPerEval = 11;
+        params.nbIterationsPerPolicyEvaluation = 3;
+        params.ratioDeletedRoots =
+            0.95; // high number to force the apparition of root action.
+        params.nbThreads = 1;
+        params.nbProgramConstant = 5;
+
+        set.add(*(new Instructions::AddPrimitiveType<double>()));
+        set.add(*(new Instructions::MultByConstant<double>()));
+
+        auto res1 = new Learn::EvaluationResult(5, 2);
+        auto res2 = new Learn::EvaluationResult(10, 2);
+        auto v1(new TPG::TPGAction(0));
+        auto v2(new TPG::TPGAction(0));
+        results.insert(std::pair<std::shared_ptr<Learn::EvaluationResult>,
+                                 const TPG::TPGVertex*>(res1, v1));
+        results.insert(std::pair<std::shared_ptr<Learn::EvaluationResult>,
+                                 const TPG::TPGVertex*>(res2, v2));
+
+        la = new Learn::LearningAgent(le, set, params);
+    }
+
+    void TearDown() override
+    {
+        delete (&set.getInstruction(0));
+        delete (&set.getInstruction(1));
+        auto it = results.begin();
+        delete it->second;
+        it++;
+        delete it->second;
+        delete la;
+    }
+};
+
+TEST_F(CycleDetectionLoggerTest, Constructor)
+{
+    Log::CycleDetectionLALogger* l = nullptr;
+    ASSERT_NO_THROW(l = new Log::CycleDetectionLALogger(*la));
+    if (l != nullptr) {
+        delete l;
+    }
+    ASSERT_NO_THROW(Log::CycleDetectionLALogger l(*la, std::cerr));
+}

--- a/test/cycleDetectionLALoggerTest.cpp
+++ b/test/cycleDetectionLALoggerTest.cpp
@@ -144,6 +144,13 @@ TEST_F(CycleDetectionLoggerTest, logAfterPopulateTPG)
 
     ASSERT_EQ(s.length(), 0) << "Custom TPG does not contain any cycle.";
 
+    // Check with a "positive" detection for this case
+    std::stringstream strStr2;
+    Log::CycleDetectionLALogger l2(*la, strStr2, true);
+    l2.logAfterPopulateTPG();
+    ASSERT_EQ(strStr2.str(), "No cycle detected in this TPG.")
+        << "Logging from \"logOnDetection\" logger in incorrect.";
+
     // Add a cycle to the graph
     // A subgraph won't be traversed by the DFS because it has no root.
     //

--- a/test/cycleDetectionLALoggerTest.cpp
+++ b/test/cycleDetectionLALoggerTest.cpp
@@ -86,6 +86,28 @@ TEST_F(CycleDetectionLoggerTest, Constructor)
     ASSERT_NO_THROW(Log::CycleDetectionLALogger l(*la, std::cerr));
 }
 
+TEST_F(CycleDetectionLoggerTest, EmptyMethods)
+{
+    la->init();
+    std::stringstream strStr;
+    Log::CycleDetectionLALogger l(*la, strStr);
+
+    // Call to all empty methods
+    l.logAfterDecimate();
+    std::multimap<std::shared_ptr<Learn::EvaluationResult>,
+                  const TPG::TPGVertex*>
+        results;
+    l.logAfterEvaluate(results);
+    l.logAfterValidate(results);
+    l.logEndOfTraining();
+    l.logHeader();
+    uint64_t generation;
+    l.logNewGeneration(generation);
+
+    ASSERT_EQ(strStr.str().length(), 0)
+        << "Empty methods should not generate any log.";
+}
+
 TEST_F(CycleDetectionLoggerTest, logAfterPopulateTPG)
 {
     la->init();


### PR DESCRIPTION
Add a `Log::CycleDetectionLALogger` for detecting directed cycles in TPG graphs. Using this logger, the detection is automatically at each generation right after populating the TPG with new vertices. In case a cycle is detected, a message is printed in `std::cerr`. By default no message is printed if no cycle is detected. This can be customized when instantiating the class.