### PR TITLE
Timing selection metrics

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ _yyyy.mm.dd_
     * Implementation of the MapElites algorithm, with an archive storing the best agents respectively to the different descriptors used for the archive. The archive can be either a classic table or a table generated through a Centroid Voronoï Tesselation computation (CVT). The implementation of the MapElitesSelector allows to create N archives for a single population. A default Descrirptor is implemented, for continuous environment, extracting the action values
   * ClassificationSelector:
     * Selector based on the former doSelection method in ClassificationLearningAgent. The classification selector allows to delete the ClassificationLearningAgent class, in order to improve the modularisation of the componenent of Gegelati.
+* Optional timers for environment and agent runtimes have been added.
 
 ### Changes 
 * Add unique IDs for TPGVertex, TPGEdges and Program.

--- a/gegelatilib/include/learn/learningParameters.h
+++ b/gegelatilib/include/learn/learningParameters.h
@@ -163,6 +163,13 @@ namespace Learn {
         size_t nbThreads = std::thread::hardware_concurrency();
 
         /// JSon comment
+        inline static const std::string detailedTimingComment =
+            "// Boolean used to activate detailed timing during learning.\n"
+            "// \"detailedTiming\" : false, // Default value";
+        /// @brief enable detailed timing during learning
+        bool detailedTiming = false;
+
+        /// JSon comment
         inline static const std::string activationFunctionComment =
             "// string that indicate the activation function used for "
             "continuous actions \n"

--- a/gegelatilib/include/log/laLogger.h
+++ b/gegelatilib/include/log/laLogger.h
@@ -138,6 +138,10 @@ namespace Log {
          */
         bool useUtility = false;
 
+        /// @brief Boolean telling the logger if the training has additional
+        /// timers.
+        bool detailedTiming = false;
+
         /**
          * \brief Constructor defining a given output and setting start and
          * checkpoint as now. Default output is cout.

--- a/gegelatilib/include/selector/selectionMetrics.h
+++ b/gegelatilib/include/selector/selectionMetrics.h
@@ -135,7 +135,7 @@ namespace Selector {
          * valueOther.
          */
         template <class T>
-        static double weightedSum(T value, T valueOther, size_t nbEvaluation,
+        static T weightedSum(T value, T valueOther, size_t nbEvaluation,
                                   size_t nbEvaluationOther)
         {
             value = value * (T)nbEvaluation + valueOther * (T)nbEvaluationOther;

--- a/gegelatilib/include/selector/selectionMetrics.h
+++ b/gegelatilib/include/selector/selectionMetrics.h
@@ -136,7 +136,7 @@ namespace Selector {
          */
         template <class T>
         static T weightedSum(T value, T valueOther, size_t nbEvaluation,
-                                  size_t nbEvaluationOther)
+                             size_t nbEvaluationOther)
         {
             value = value * (T)nbEvaluation + valueOther * (T)nbEvaluationOther;
             value /= (T)(nbEvaluation + nbEvaluationOther);

--- a/gegelatilib/include/selector/selectionMetrics.h
+++ b/gegelatilib/include/selector/selectionMetrics.h
@@ -116,6 +116,32 @@ namespace Selector {
          */
         virtual void weightedSum(std::shared_ptr<SelectionMetrics> other,
                                  size_t nbEvaluation, size_t nbEvaluationOther);
+
+        /// @brief Comparison function to enable sorting of SelectionMetrics
+        /// with STL.
+        friend bool operator<(const SelectionMetrics& lhs,
+                              const SelectionMetrics& rhs)
+        {
+            return lhs.getScore() < rhs.getScore();
+        }
+
+        /**
+         * \brief Perform a weighted sum between 2 values.
+         *
+         * \param[in] value the value to combine.
+         * \param[in] valueOther the other value to combine.
+         * \param[in] nbEvaluation the number of evaluations to obtain value.
+         * \param[in] nbEvaluationOther the number of evaluations to obtain
+         * valueOther.
+         */
+        template <class T>
+        static double weightedSum(T value, T valueOther, size_t nbEvaluation,
+                                  size_t nbEvaluationOther)
+        {
+            value = value * (T)nbEvaluation + valueOther * (T)nbEvaluationOther;
+            value /= (T)(nbEvaluation + nbEvaluationOther);
+            return value;
+        }
     };
 
     /**

--- a/gegelatilib/include/selector/selectionMetrics.h
+++ b/gegelatilib/include/selector/selectionMetrics.h
@@ -38,6 +38,9 @@ namespace Selector {
          */
         SelectionMetrics() = default;
 
+        /// @brief Default destructor
+        virtual ~SelectionMetrics() = default;
+
         /**
          * \brief Constructor with score and utility initialization.
          *

--- a/gegelatilib/include/selector/timingSelectionMetrics.h
+++ b/gegelatilib/include/selector/timingSelectionMetrics.h
@@ -74,8 +74,8 @@ namespace Selector {
         /// the episode
         /// \param[in] learningEnvironment the learning environment in which the
         /// agent is evaluated.
-        /// @param[in] agentTime execution time of learning agent.
-        /// @param[in] leTime execution time of learning environment.
+        /// @param[in] agentTimeEpisode execution time of learning agent.
+        /// @param[in] leTimeEpisode execution time of learning environment.
         void extractMetricsEpisodeWithTiming(
             const TPG::TPGVertex* agent, size_t nbStepsExecuted,
             const Learn::LearningEnvironment& learningEnvironment,

--- a/gegelatilib/include/selector/timingSelectionMetrics.h
+++ b/gegelatilib/include/selector/timingSelectionMetrics.h
@@ -21,6 +21,9 @@ namespace Selector {
         size_t nbActions = 0;
 
       public:
+        /// @brief Default destructor
+        virtual ~TimingSelectionMetrics() = default;
+
         /// @brief Return the execution time of learning agent.
         /// @return Execution time of learning agent.
         double getAgentTime() const
@@ -61,11 +64,11 @@ namespace Selector {
         /// @brief Constructor for the SelectionMetrics with timing.
         /// @param obj SelectionMetrics being timed.
         explicit TimingSelectionMetrics(std::shared_ptr<SelectionMetrics> obj)
-            : wrapped(obj){};
+            : wrapped(obj) {};
 
         /// @brief Forward to wrapped method
         void extractMetricsStep(
-            const TPG::TPGVertex* agent, std::vector<double> actionValues,
+            const TPG::TPGVertex* agent, const std::vector<double> actionValues,
             const Learn::LearningEnvironment& learningEnvironment) override;
 
         /// @brief Specialization of extractMetricsEpisode to add timings.

--- a/gegelatilib/include/selector/timingSelectionMetrics.h
+++ b/gegelatilib/include/selector/timingSelectionMetrics.h
@@ -45,7 +45,7 @@ namespace Selector {
         /**
          * Return the score of the agent.
          */
-        virtual double getScore() const override
+        double getScore() const override
         {
             return wrapped->getScore();
         };
@@ -53,18 +53,18 @@ namespace Selector {
         /**
          * Return the utility of the agent.
          */
-        virtual double getUtility() const override
+        double getUtility() const override
         {
             return wrapped->getUtility();
         };
 
         /// @brief Constructor for the SelectionMetrics with timing.
         /// @param obj SelectionMetrics being timed.
-        TimingSelectionMetrics(std::shared_ptr<SelectionMetrics> obj)
+        explicit TimingSelectionMetrics(std::shared_ptr<SelectionMetrics> obj)
             : wrapped(obj) {};
 
         /// @brief Forward to wrapped method
-        virtual void extractMetricsStep(
+        void extractMetricsStep(
             const TPG::TPGVertex* agent, std::vector<double> actionValues,
             const Learn::LearningEnvironment& learningEnvironment) override;
 
@@ -76,15 +76,15 @@ namespace Selector {
         /// agent is evaluated.
         /// @param[in] agentTime execution time of learning agent.
         /// @param[in] leTime execution time of learning environment.
-        void extractMetricsEpisode(
+        void extractMetricsEpisodeWithTiming(
             const TPG::TPGVertex* agent, size_t nbStepsExecuted,
             const Learn::LearningEnvironment& learningEnvironment,
-            double agentTime, double leTime);
+            double agentTimeEpisode, double leTimeEpisode);
 
         /// @brief Specialization of weightedSum to add timings and nbActions.
-        virtual void weightedSum(std::shared_ptr<SelectionMetrics> other,
-                                 size_t nbEvaluation,
-                                 size_t nbEvaluationOther) override;
+        void weightedSum(std::shared_ptr<SelectionMetrics> other,
+                         size_t nbEvaluation,
+                         size_t nbEvaluationOther) override;
     };
 
     /// @brief Comparison function to enable sorting of SelectionMetrics with STL.

--- a/gegelatilib/include/selector/timingSelectionMetrics.h
+++ b/gegelatilib/include/selector/timingSelectionMetrics.h
@@ -61,7 +61,7 @@ namespace Selector {
         /// @brief Constructor for the SelectionMetrics with timing.
         /// @param obj SelectionMetrics being timed.
         explicit TimingSelectionMetrics(std::shared_ptr<SelectionMetrics> obj)
-            : wrapped(obj) {};
+            : wrapped(obj){};
 
         /// @brief Forward to wrapped method
         void extractMetricsStep(
@@ -87,15 +87,18 @@ namespace Selector {
                          size_t nbEvaluationOther) override;
     };
 
-    /// @brief Comparison function to enable sorting of SelectionMetrics with STL.
+    /// @brief Comparison function to enable sorting of SelectionMetrics with
+    /// STL.
     bool operator<(std::shared_ptr<TimingSelectionMetrics> a,
                    std::shared_ptr<TimingSelectionMetrics> b);
 
-    /// @brief Comparison function to enable sorting of SelectionMetrics with STL.
+    /// @brief Comparison function to enable sorting of SelectionMetrics with
+    /// STL.
     bool operator<(std::shared_ptr<SelectionMetrics> a,
                    std::shared_ptr<TimingSelectionMetrics> b);
 
-    /// @brief Comparison function to enable sorting of SelectionMetrics with STL.
+    /// @brief Comparison function to enable sorting of SelectionMetrics with
+    /// STL.
     bool operator<(std::shared_ptr<TimingSelectionMetrics> a,
                    std::shared_ptr<SelectionMetrics> b);
 }; // namespace Selector

--- a/gegelatilib/include/selector/timingSelectionMetrics.h
+++ b/gegelatilib/include/selector/timingSelectionMetrics.h
@@ -1,0 +1,103 @@
+#ifndef TIMING_SELECTION_METRICS_H
+#define TIMING_SELECTION_METRICS_H
+
+#include "selector/selectionMetrics.h"
+
+namespace Selector {
+    /// @brief Decorator on SelectionMetrics class to add timing informations.
+    class TimingSelectionMetrics : public SelectionMetrics
+    {
+      protected:
+        /// @brief wrapped SelectionMetrics to time.
+        std::shared_ptr<SelectionMetrics> wrapped;
+
+        /// @brief Execution time of learning agent.
+        double agentTime = 0;
+
+        /// @brief Execution time of learning environment.
+        double leTime = 0;
+
+        /// @brief Number of actions performed.
+        size_t nbActions = 0;
+
+      public:
+        /// @brief Return the execution time of learning agent.
+        /// @return Execution time of learning agent.
+        double getAgentTime() const
+        {
+            return agentTime;
+        }
+
+        /// @brief Return the execution time of learning environment.
+        /// @return Execution time of learning environment.
+        double getLeTime() const
+        {
+            return leTime;
+        }
+
+        /// @brief Return the number of actions performed.
+        /// @return Number of actions performed.
+        size_t getNbActions() const
+        {
+            return nbActions;
+        }
+
+        /**
+         * Return the score of the agent.
+         */
+        virtual double getScore() const override
+        {
+            return wrapped->getScore();
+        };
+
+        /**
+         * Return the utility of the agent.
+         */
+        virtual double getUtility() const override
+        {
+            return wrapped->getUtility();
+        };
+
+        /// @brief Constructor for the SelectionMetrics with timing.
+        /// @param obj SelectionMetrics being timed.
+        TimingSelectionMetrics(std::shared_ptr<SelectionMetrics> obj)
+            : wrapped(obj) {};
+
+        /// @brief Forward to wrapped method
+        virtual void extractMetricsStep(
+            const TPG::TPGVertex* agent, std::vector<double> actionValues,
+            const Learn::LearningEnvironment& learningEnvironment) override;
+
+        /// @brief Specialization of extractMetricsEpisode to add timings.
+        /// \param[in] agent the TPGVertex representing the agent
+        /// \param[in] nbStepsExecuted number of steps executed at the end of
+        /// the episode
+        /// \param[in] learningEnvironment the learning environment in which the
+        /// agent is evaluated.
+        /// @param[in] agentTime execution time of learning agent.
+        /// @param[in] leTime execution time of learning environment.
+        void extractMetricsEpisode(
+            const TPG::TPGVertex* agent, size_t nbStepsExecuted,
+            const Learn::LearningEnvironment& learningEnvironment,
+            double agentTime, double leTime);
+
+        /// @brief Specialization of weightedSum to add timings and nbActions.
+        virtual void weightedSum(std::shared_ptr<SelectionMetrics> other,
+                                 size_t nbEvaluation,
+                                 size_t nbEvaluationOther) override;
+    };
+
+    /// @brief Comparison function to enable sorting of SelectionMetrics with STL.
+    bool operator<(std::shared_ptr<TimingSelectionMetrics> a,
+                   std::shared_ptr<TimingSelectionMetrics> b);
+
+    /// @brief Comparison function to enable sorting of SelectionMetrics with STL.
+    bool operator<(std::shared_ptr<SelectionMetrics> a,
+                   std::shared_ptr<TimingSelectionMetrics> b);
+
+    /// @brief Comparison function to enable sorting of SelectionMetrics with STL.
+    bool operator<(std::shared_ptr<TimingSelectionMetrics> a,
+                   std::shared_ptr<SelectionMetrics> b);
+}; // namespace Selector
+
+#endif // TIMING_SELECTION_METRICS_H

--- a/gegelatilib/include/selector/timingSelectionMetrics.h
+++ b/gegelatilib/include/selector/timingSelectionMetrics.h
@@ -64,7 +64,7 @@ namespace Selector {
         /// @brief Constructor for the SelectionMetrics with timing.
         /// @param obj SelectionMetrics being timed.
         explicit TimingSelectionMetrics(std::shared_ptr<SelectionMetrics> obj)
-            : wrapped(obj) {};
+            : wrapped(obj){};
 
         /// @brief Forward to wrapped method
         void extractMetricsStep(

--- a/gegelatilib/src/file/parametersParser.cpp
+++ b/gegelatilib/src/file/parametersParser.cpp
@@ -161,6 +161,10 @@ void File::ParametersParser::setParameterFromString(
         params.nbThreads = (size_t)value.asUInt();
         return;
     }
+    if (param == "detailedTiming") {
+        params.detailedTiming = value.asBool();
+        return;
+    }
     if (param == "nbGenerations") {
         params.nbGenerations = value.asUInt64();
         return;
@@ -419,6 +423,10 @@ void File::ParametersParser::writeParametersToJson(
     root["nbThreads"] = params.nbThreads;
     root["nbThreads"].setComment(Learn::LearningParameters::nbThreadsComment,
                                  Json::commentBefore);
+
+    root["detailedTiming"] = params.detailedTiming;
+    root["detailedTiming"].setComment(
+        Learn::LearningParameters::detailedTimingComment, Json::commentBefore);
 
     // Mutation.tpg parameters
     root["mutation"]["tpg"]["forceProgramBehaviorChangeOnMutation"] =

--- a/gegelatilib/src/learn/learningAgent.cpp
+++ b/gegelatilib/src/learn/learningAgent.cpp
@@ -44,6 +44,7 @@
 #include "learn/evaluationResult.h"
 #include "mutator/rng.h"
 #include "mutator/tpgMutator.h"
+#include "selector/timingSelectionMetrics.h"
 #include "tpg/tpgExecutionEngine.h"
 
 #include "learn/learningAgent.h"
@@ -99,6 +100,7 @@ void Learn::LearningAgent::addLogger(Log::LALogger& logger)
 {
     logger.doValidation = this->params.doValidation;
     logger.useUtility = this->learningEnvironment.isUsingUtility();
+    logger.detailedTiming = this->params.detailedTiming;
     // logs for example the headers of the columns the logger will print
     loggers.push_back(std::reference_wrapper<Log::LALogger>(logger));
 }
@@ -151,6 +153,11 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateJob(
     // Init global selection metric
     std::shared_ptr<Selector::SelectionMetrics> globalSelectionMetrics =
         this->selector->createSelectionMetrics();
+    if (params.detailedTiming) {
+        globalSelectionMetrics =
+            std::shared_ptr<Selector::TimingSelectionMetrics>(
+                new Selector::TimingSelectionMetrics(globalSelectionMetrics));
+    }
     globalSelectionMetrics->initMetrics(root, le);
 
     // Evaluate nbIteration times
@@ -163,29 +170,69 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateJob(
         // Init selectionMetrics for this episode.
         std::shared_ptr<Selector::SelectionMetrics> selectionMetrics =
             this->selector->createSelectionMetrics();
+        if (params.detailedTiming) {
+            selectionMetrics =
+                std::shared_ptr<Selector::TimingSelectionMetrics>(
+                    new Selector::TimingSelectionMetrics(selectionMetrics));
+        }
         selectionMetrics->initMetrics(root, le);
 
         // Reset the learning Environment
         le.reset(hash, mode, iterationNumber, generationNumber);
 
-        uint64_t nbActions = 0;
-        while (!le.isTerminal() &&
-               nbActions < this->params.maxNbActionsPerEval) {
-            // Get the actions
-            std::vector<double> actionsID =
-                tee.executeFromRoot(*root, le.getInitActions()).second;
-            // Do it
-            le.doActions(actionsID);
-            // Count actions
-            nbActions++;
+        if (params.detailedTiming) {
+            uint64_t nbActions = 0;
+            double agentTime = 0;
+            double leTime = 0;
+            while (!le.isTerminal() &&
+                   nbActions < this->params.maxNbActionsPerEval) {
+                // Get the actions
+                auto startTime = std::chrono::system_clock::now();
+                std::vector<double> actionsID =
+                    tee.executeFromRoot(*root, le.getInitActions()).second;
+                auto endTime = std::chrono::system_clock::now();
+                agentTime +=
+                    ((std::chrono::duration<double>)(endTime - startTime))
+                        .count();
+                // Do it
+                startTime = endTime;
+                le.doActions(actionsID);
+                endTime = std::chrono::system_clock::now();
+                leTime += ((std::chrono::duration<double>)(endTime - startTime))
+                              .count();
+                // Count actions
+                nbActions++;
+
+                // Extract the metrics.
+                selectionMetrics->extractMetricsStep(root, actionsID, le);
+            }
 
             // Extract the metrics.
-            selectionMetrics->extractMetricsStep(root, actionsID, le);
+            auto timedSectionMetrics =
+                std::static_pointer_cast<Selector::TimingSelectionMetrics>(
+                    selectionMetrics);
+            timedSectionMetrics->extractMetricsEpisode(root, nbActions, le,
+                                                       agentTime, leTime);
         }
+        else {
+            uint64_t nbActions = 0;
+            while (!le.isTerminal() &&
+                   nbActions < this->params.maxNbActionsPerEval) {
+                // Get the actions
+                std::vector<double> actionsID =
+                    tee.executeFromRoot(*root, le.getInitActions()).second;
+                // Do it
+                le.doActions(actionsID);
+                // Count actions
+                nbActions++;
 
-        // Extract the metrics.
-        selectionMetrics->extractMetricsEpisode(root, nbActions, le);
+                // Extract the metrics.
+                selectionMetrics->extractMetricsStep(root, actionsID, le);
+            }
 
+            // Extract the metrics.
+            selectionMetrics->extractMetricsEpisode(root, nbActions, le);
+        }
         // Add the extracted metrics to the total.
         globalSelectionMetrics->weightedSum(selectionMetrics, iterationNumber,
                                             1);

--- a/gegelatilib/src/learn/learningAgent.cpp
+++ b/gegelatilib/src/learn/learningAgent.cpp
@@ -155,8 +155,8 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateJob(
         this->selector->createSelectionMetrics();
     if (params.detailedTiming) {
         globalSelectionMetrics =
-            std::shared_ptr<Selector::TimingSelectionMetrics>(
-                new Selector::TimingSelectionMetrics(globalSelectionMetrics));
+            std::make_shared<Selector::TimingSelectionMetrics>(
+                Selector::TimingSelectionMetrics(globalSelectionMetrics));
     }
     globalSelectionMetrics->initMetrics(root, le);
 
@@ -172,8 +172,8 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateJob(
             this->selector->createSelectionMetrics();
         if (params.detailedTiming) {
             selectionMetrics =
-                std::shared_ptr<Selector::TimingSelectionMetrics>(
-                    new Selector::TimingSelectionMetrics(selectionMetrics));
+                std::make_shared<Selector::TimingSelectionMetrics>(
+                    Selector::TimingSelectionMetrics(selectionMetrics));
         }
         selectionMetrics->initMetrics(root, le);
 
@@ -211,8 +211,8 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateJob(
             auto timedSectionMetrics =
                 std::static_pointer_cast<Selector::TimingSelectionMetrics>(
                     selectionMetrics);
-            timedSectionMetrics->extractMetricsEpisode(root, nbActions, le,
-                                                       agentTime, leTime);
+            timedSectionMetrics->extractMetricsEpisodeWithTiming(
+                root, nbActions, le, agentTime, leTime);
         }
         else {
             uint64_t nbActions = 0;

--- a/gegelatilib/src/learn/learningAgent.cpp
+++ b/gegelatilib/src/learn/learningAgent.cpp
@@ -156,7 +156,7 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateJob(
     if (params.detailedTiming) {
         globalSelectionMetrics =
             std::make_shared<Selector::TimingSelectionMetrics>(
-                Selector::TimingSelectionMetrics(globalSelectionMetrics));
+                globalSelectionMetrics);
     }
     globalSelectionMetrics->initMetrics(root, le);
 
@@ -173,7 +173,7 @@ std::shared_ptr<Learn::EvaluationResult> Learn::LearningAgent::evaluateJob(
         if (params.detailedTiming) {
             selectionMetrics =
                 std::make_shared<Selector::TimingSelectionMetrics>(
-                    Selector::TimingSelectionMetrics(selectionMetrics));
+                    selectionMetrics);
         }
         selectionMetrics->initMetrics(root, le);
 

--- a/gegelatilib/src/log/laBasicLogger.cpp
+++ b/gegelatilib/src/log/laBasicLogger.cpp
@@ -69,10 +69,10 @@ void Log::LABasicLogger::logResults(
               << std::setw(colWidth) << max;
     };
 
-    auto logTimingStat = [&]<class T>(T val, auto getter) {
+    auto logTimingStat = [&](auto val, auto getter) {
         val = std::accumulate(
             results.begin(), results.end(), 0.0,
-            [getter](T acc,
+            [getter](auto acc,
                      const std::pair<std::shared_ptr<Learn::EvaluationResult>,
                                      const TPG::TPGVertex*>& pair) {
                 return acc + (std::static_pointer_cast<

--- a/gegelatilib/src/log/laBasicLogger.cpp
+++ b/gegelatilib/src/log/laBasicLogger.cpp
@@ -69,10 +69,10 @@ void Log::LABasicLogger::logResults(
               << std::setw(colWidth) << max;
     };
 
-    auto logTimingStat = [&](auto val, auto getter) {
+    auto logTimingStat = [&]<class T>(T val, auto getter) {
         val = std::accumulate(
             results.begin(), results.end(), 0.0,
-            [getter](auto acc,
+            [getter](T acc,
                      const std::pair<std::shared_ptr<Learn::EvaluationResult>,
                                      const TPG::TPGVertex*>& pair) {
                 return acc + (std::static_pointer_cast<
@@ -216,7 +216,7 @@ void Log::LABasicLogger::logAfterValidate(
         logResults(results);
     }
     else {
-        size_t rows = 3;
+        int rows = 3;
         rows += useUtility ? 3 : 0;
         rows += detailedTiming ? 3 : 0;
         *this << std::setw(rows * colWidth) << " ";

--- a/gegelatilib/src/log/laBasicLogger.cpp
+++ b/gegelatilib/src/log/laBasicLogger.cpp
@@ -39,6 +39,7 @@
 #include <numeric>
 
 #include "learn/learningAgent.h"
+#include "selector/timingSelectionMetrics.h"
 
 #include "log/laBasicLogger.h"
 
@@ -68,10 +69,30 @@ void Log::LABasicLogger::logResults(
               << std::setw(colWidth) << max;
     };
 
+    auto logTimingStat = [&](auto val, auto getter) {
+        val = std::accumulate(
+            results.begin(), results.end(), 0.0,
+            [getter](auto acc,
+                     const std::pair<std::shared_ptr<Learn::EvaluationResult>,
+                                     const TPG::TPGVertex*>& pair) {
+                return acc + (std::static_pointer_cast<
+                                  Selector::TimingSelectionMetrics>(
+                                  pair.first->getSelectionMetrics())
+                                  .get()
+                                  ->*getter)();
+            });
+        *this << std::setw(colWidth) << val;
+    };
+
     if (useUtility) {
         logStat(&Selector::SelectionMetrics::getUtility);
     }
     logStat(&Selector::SelectionMetrics::getScore);
+    if (detailedTiming) {
+        logTimingStat(0.0, &Selector::TimingSelectionMetrics::getAgentTime);
+        logTimingStat(0.0, &Selector::TimingSelectionMetrics::getLeTime);
+        logTimingStat(0, &Selector::TimingSelectionMetrics::getNbActions);
+    }
 }
 
 void Log::LABasicLogger::logHeader()
@@ -80,11 +101,15 @@ void Log::LABasicLogger::logHeader()
     //*this << std::left;
 
     *this << std::setw(5 * colWidth) << " ";
+    if (detailedTiming)
+        *this << std::setw(2 * colWidth) << " ";
     if (useUtility)
         *this << std::setw((int)(1.5 * colWidth)) << " ";
     *this << std::setw(colWidth) << "Train";
     if (doValidation) {
         *this << std::setw((int)(2.5 * colWidth)) << " ";
+        if (detailedTiming)
+            *this << std::setw(3 * colWidth) << " ";
         if (useUtility)
             *this << std::setw((int)(3 * colWidth)) << "  ";
         *this << "Valid";
@@ -107,6 +132,10 @@ void Log::LABasicLogger::logHeader()
         *this << std::setw(colWidth) << "Min" << std::setw(colWidth) << "Avg"
               << std::setw(colWidth) << "Max";
     }
+    if (detailedTiming) {
+        *this << std::setw(colWidth) << "T_agent" << std::setw(colWidth)
+              << "T_le" << std::setw(colWidth) << "nb_act";
+    }
 
     if (doValidation) {
         if (useUtility) {
@@ -118,6 +147,10 @@ void Log::LABasicLogger::logHeader()
         else {
             *this << std::setw(colWidth) << "Min" << std::setw(colWidth)
                   << "Avg" << std::setw(colWidth) << "Max";
+        }
+        if (detailedTiming) {
+            *this << std::setw(colWidth) << "T_agent" << std::setw(colWidth)
+                  << "T_le" << std::setw(colWidth) << "nb_act";
         }
     }
 
@@ -183,10 +216,10 @@ void Log::LABasicLogger::logAfterValidate(
         logResults(results);
     }
     else {
-        size_t multiplier = 3;
-        if (useUtility)
-            multiplier *= 2;
-        *this << std::setw(multiplier * colWidth) << " ";
+        size_t rows = 3;
+        rows += useUtility ? 3 : 0;
+        rows += detailedTiming ? 3 : 0;
+        *this << std::setw(rows * colWidth) << " ";
     }
 }
 

--- a/gegelatilib/src/selector/selectionMetrics.cpp
+++ b/gegelatilib/src/selector/selectionMetrics.cpp
@@ -32,17 +32,13 @@ void Selector::SelectionMetrics::weightedSum(
         throw std::runtime_error("Type mismatch between SelectionMetrics.");
     }
 
-    this->score = this->score * (double)nbEvaluation +
-                  other->score * (double)nbEvaluationOther;
-    this->score /= (double)(nbEvaluation + nbEvaluationOther);
-
-    this->utility = this->score * (double)nbEvaluation +
-                    other->utility * (double)nbEvaluationOther;
-    this->utility /= (double)(nbEvaluation + nbEvaluationOther);
+    score = weightedSum(score, other->score, nbEvaluation, nbEvaluationOther);
+    utility =
+        weightedSum(utility, other->utility, nbEvaluation, nbEvaluationOther);
 }
 
 bool Selector::operator<(std::shared_ptr<SelectionMetrics> a,
                          std::shared_ptr<SelectionMetrics> b)
 {
-    return a->getScore() < b->getScore();
+    return *a < *b;
 }

--- a/gegelatilib/src/selector/timingSelectionMetrics.cpp
+++ b/gegelatilib/src/selector/timingSelectionMetrics.cpp
@@ -1,7 +1,7 @@
 #include "selector/timingSelectionMetrics.h"
 
 void Selector::TimingSelectionMetrics::extractMetricsStep(
-    const TPG::TPGVertex* agent, std::vector<double> actionValues,
+    const TPG::TPGVertex* agent, const std::vector<double> actionValues,
     const Learn::LearningEnvironment& learningEnvironment)
 {
     wrapped->extractMetricsStep(agent, actionValues, learningEnvironment);

--- a/gegelatilib/src/selector/timingSelectionMetrics.cpp
+++ b/gegelatilib/src/selector/timingSelectionMetrics.cpp
@@ -9,8 +9,8 @@ void Selector::TimingSelectionMetrics::extractMetricsStep(
 
 void Selector::TimingSelectionMetrics::extractMetricsEpisodeWithTiming(
     const TPG::TPGVertex* agent, size_t nbStepsExecuted,
-    const Learn::LearningEnvironment& learningEnvironment, double agentTimeEpisode,
-    double leTimeEpisode)
+    const Learn::LearningEnvironment& learningEnvironment,
+    double agentTimeEpisode, double leTimeEpisode)
 {
     wrapped->extractMetricsEpisode(agent, nbStepsExecuted, learningEnvironment);
 

--- a/gegelatilib/src/selector/timingSelectionMetrics.cpp
+++ b/gegelatilib/src/selector/timingSelectionMetrics.cpp
@@ -7,16 +7,16 @@ void Selector::TimingSelectionMetrics::extractMetricsStep(
     wrapped->extractMetricsStep(agent, actionValues, learningEnvironment);
 };
 
-void Selector::TimingSelectionMetrics::extractMetricsEpisode(
+void Selector::TimingSelectionMetrics::extractMetricsEpisodeWithTiming(
     const TPG::TPGVertex* agent, size_t nbStepsExecuted,
-    const Learn::LearningEnvironment& learningEnvironment, double agentTime,
-    double leTime)
+    const Learn::LearningEnvironment& learningEnvironment, double agentTimeEpisode,
+    double leTimeEpisode)
 {
     wrapped->extractMetricsEpisode(agent, nbStepsExecuted, learningEnvironment);
 
     nbActions += nbStepsExecuted;
-    this->agentTime += agentTime;
-    this->leTime += leTime;
+    agentTime += agentTimeEpisode;
+    leTime += leTimeEpisode;
 }
 
 void Selector::TimingSelectionMetrics::weightedSum(

--- a/gegelatilib/src/selector/timingSelectionMetrics.cpp
+++ b/gegelatilib/src/selector/timingSelectionMetrics.cpp
@@ -1,0 +1,57 @@
+#include "selector/timingSelectionMetrics.h"
+
+void Selector::TimingSelectionMetrics::extractMetricsStep(
+    const TPG::TPGVertex* agent, std::vector<double> actionValues,
+    const Learn::LearningEnvironment& learningEnvironment)
+{
+    wrapped->extractMetricsStep(agent, actionValues, learningEnvironment);
+};
+
+void Selector::TimingSelectionMetrics::extractMetricsEpisode(
+    const TPG::TPGVertex* agent, size_t nbStepsExecuted,
+    const Learn::LearningEnvironment& learningEnvironment, double agentTime,
+    double leTime)
+{
+    wrapped->extractMetricsEpisode(agent, nbStepsExecuted, learningEnvironment);
+
+    nbActions += nbStepsExecuted;
+    this->agentTime += agentTime;
+    this->leTime += leTime;
+}
+
+void Selector::TimingSelectionMetrics::weightedSum(
+    std::shared_ptr<SelectionMetrics> other, size_t nbEvaluation,
+    size_t nbEvaluationOther)
+{
+    if (auto tother = dynamic_cast<TimingSelectionMetrics*>(other.get())) {
+        wrapped->weightedSum(tother->wrapped, nbEvaluation, nbEvaluationOther);
+
+        agentTime = SelectionMetrics::weightedSum(
+            agentTime, tother->agentTime, nbEvaluation, nbEvaluationOther);
+        leTime = SelectionMetrics::weightedSum(leTime, tother->leTime,
+                                               nbEvaluation, nbEvaluationOther);
+        nbActions = SelectionMetrics::weightedSum(
+            nbActions, tother->nbActions, nbEvaluation, nbEvaluationOther);
+    }
+    else {
+        throw std::runtime_error("Type mismatch between SelectionMetrics.");
+    }
+}
+
+bool Selector::operator<(std::shared_ptr<TimingSelectionMetrics> a,
+                         std::shared_ptr<TimingSelectionMetrics> b)
+{
+    return *a < *b;
+}
+
+bool Selector::operator<(std::shared_ptr<SelectionMetrics> a,
+                         std::shared_ptr<TimingSelectionMetrics> b)
+{
+    return *a < *b;
+}
+
+bool Selector::operator<(std::shared_ptr<TimingSelectionMetrics> a,
+                         std::shared_ptr<SelectionMetrics> b)
+{
+    return *a < *b;
+}

--- a/test/laBasicLoggerTest.cpp
+++ b/test/laBasicLoggerTest.cpp
@@ -43,6 +43,7 @@
 #include "instructions/multByConstant.h"
 #include "learn/learningAgent.h"
 #include "learn/stickGameWithOpponent.h"
+#include "selector/timingSelectionMetrics.h"
 
 #include "log/laBasicLogger.h"
 
@@ -91,10 +92,14 @@ class LABasicLoggerTest : public ::testing::Test
         set.add(*(new Instructions::AddPrimitiveType<double>()));
         set.add(*(new Instructions::MultByConstant<double>()));
 
-        auto res1 = new Learn::EvaluationResult(
-            std::make_shared<Selector::SelectionMetrics>(5, 2), 2);
-        auto res2 = new Learn::EvaluationResult(
-            std::make_shared<Selector::SelectionMetrics>(10, 4), 2);
+        auto tsm1 = std::make_shared<Selector::TimingSelectionMetrics>(
+            std::make_shared<Selector::SelectionMetrics>(5, 2));
+        tsm1->extractMetricsEpisode(nullptr, 2, le, 5, 3);
+        auto res1 = new Learn::EvaluationResult(tsm1, 2);
+        auto tsm2 = std::make_shared<Selector::TimingSelectionMetrics>(
+            std::make_shared<Selector::SelectionMetrics>(10, 4));
+        tsm2->extractMetricsEpisode(nullptr, 7, le, 8, 1);
+        auto res2 = new Learn::EvaluationResult(tsm2, 2);
         auto v1(new TPG::TPGAction(0));
         auto v2(new TPG::TPGAction(0));
         results.insert(std::pair<std::shared_ptr<Learn::EvaluationResult>,
@@ -172,8 +177,12 @@ TEST_F(LABasicLoggerTest, logHeader)
     l.doValidation = true;
     l.logHeader();
 
-    // we log a third header with validation column
+    // we log a third header with utility column
     l.useUtility = true;
+    l.logHeader();
+
+    // we log a fourth header with detailed timing column
+    l.detailedTiming = true;
     l.logHeader();
 
     // now we will check the header logged correctly
@@ -205,6 +214,12 @@ TEST_F(LABasicLoggerTest, logHeader)
     ASSERT_EQ("R_Min", result[38]);
     ASSERT_EQ("R_Avg", result[39]);
     ASSERT_EQ("R_Max", result[40]);
+    ASSERT_EQ("T_agent", result[64]);
+    ASSERT_EQ("T_le", result[65]);
+    ASSERT_EQ("nb_act", result[66]);
+    ASSERT_EQ("T_agent", result[73]);
+    ASSERT_EQ("T_le", result[74]);
+    ASSERT_EQ("nb_act", result[75]);
 }
 
 TEST_F(LABasicLoggerTest, logNewGeneration)
@@ -261,6 +276,10 @@ TEST_F(LABasicLoggerTest, logAfterEvaluate)
 
     l.useUtility = true;
     l.logAfterEvaluate(results);
+
+    l.detailedTiming = true;
+    l.logAfterEvaluate(results);
+
     std::string s = strStr.str();
     // putting each element seperated by blanks in a tab
     std::vector<std::string> result;
@@ -280,6 +299,17 @@ TEST_F(LABasicLoggerTest, logAfterEvaluate)
     ASSERT_DOUBLE_EQ(5.00, std::stod(result[18]));
     ASSERT_DOUBLE_EQ(7.50, std::stod(result[19]));
     ASSERT_DOUBLE_EQ(10.00, std::stod(result[20]));
+
+    // Detailed timing
+    ASSERT_DOUBLE_EQ(2.00, std::stod(result[21]));
+    ASSERT_DOUBLE_EQ(3.00, std::stod(result[22]));
+    ASSERT_DOUBLE_EQ(4.00, std::stod(result[23]));
+    ASSERT_DOUBLE_EQ(5.00, std::stod(result[24]));
+    ASSERT_DOUBLE_EQ(7.50, std::stod(result[25]));
+    ASSERT_DOUBLE_EQ(10.00, std::stod(result[26]));
+    ASSERT_DOUBLE_EQ(13.00, std::stod(result[27]));
+    ASSERT_DOUBLE_EQ(4.00, std::stod(result[28]));
+    ASSERT_DOUBLE_EQ(9, std::stod(result[29]));
 }
 
 TEST_F(LABasicLoggerTest, logAfterValidate)

--- a/test/laBasicLoggerTest.cpp
+++ b/test/laBasicLoggerTest.cpp
@@ -94,11 +94,11 @@ class LABasicLoggerTest : public ::testing::Test
 
         auto tsm1 = std::make_shared<Selector::TimingSelectionMetrics>(
             std::make_shared<Selector::SelectionMetrics>(5, 2));
-        tsm1->extractMetricsEpisode(nullptr, 2, le, 5, 3);
+        tsm1->extractMetricsEpisodeWithTiming(nullptr, 2, le, 5, 3);
         auto res1 = new Learn::EvaluationResult(tsm1, 2);
         auto tsm2 = std::make_shared<Selector::TimingSelectionMetrics>(
             std::make_shared<Selector::SelectionMetrics>(10, 4));
-        tsm2->extractMetricsEpisode(nullptr, 7, le, 8, 1);
+        tsm2->extractMetricsEpisodeWithTiming(nullptr, 7, le, 8, 1);
         auto res2 = new Learn::EvaluationResult(tsm2, 2);
         auto v1(new TPG::TPGAction(0));
         auto v2(new TPG::TPGAction(0));

--- a/test/learningAgentTest.cpp
+++ b/test/learningAgentTest.cpp
@@ -62,6 +62,8 @@
 #include "learn/parallelLearningAgent.h"
 #include "learn/stickGameWithOpponent.h"
 
+#include "selector/timingSelectionMetrics.h"
+
 #include "util/counterReset.h"
 class LearningAgentTest : public ::testing::Test
 {
@@ -296,6 +298,45 @@ TEST_F(LearningAgentTest, EvalAllRoots)
     ASSERT_EQ(result.size(), la.getTPGGraph()->getNbRootVertices())
         << "Number of evaluated roots is under the number of roots from the "
            "TPGGraph.";
+}
+
+TEST_F(LearningAgentTest, TimedEvaluation)
+{
+    params.archiveSize = 50;
+    params.archivingProbability = 0.5;
+    params.maxNbActionsPerEval = 11;
+    params.nbIterationsPerPolicyEvaluation = 10;
+
+    Learn::LearningAgent la(le, set, params);
+
+    la.init();
+    std::multimap<std::shared_ptr<Learn::EvaluationResult>,
+                  const TPG::TPGVertex*>
+        result;
+    ASSERT_NO_THROW(result =
+                        la.evaluateAllRoots(0, Learn::LearningMode::TRAINING))
+        << "Evaluation from a root failed.";
+    auto selectionMetrics = result.begin()->first->getSelectionMetrics().get();
+    ASSERT_FALSE(
+        dynamic_cast<Selector::TimingSelectionMetrics*>(selectionMetrics))
+        << "Should not be a TimingSelectionMetrics as it is disabled by "
+           "default";
+
+    params.detailedTiming = true;
+
+    Learn::LearningAgent latimed(le, set, params);
+    latimed.init();
+
+    ASSERT_NO_THROW(
+        result = latimed.evaluateAllRoots(0, Learn::LearningMode::TRAINING))
+        << "Evaluation from a root failed.";
+    selectionMetrics = result.begin()->first->getSelectionMetrics().get();
+    ASSERT_TRUE(
+        dynamic_cast<Selector::TimingSelectionMetrics*>(selectionMetrics))
+        << "Should be a TimingSelectionMetrics as it is enabled";
+    Selector::TimingSelectionMetrics* timedSelectionMetrics =
+        static_cast<Selector::TimingSelectionMetrics*>(selectionMetrics);
+    ASSERT_GT(timedSelectionMetrics->getAgentTime(), 0) << "Agent execution time should be non null after training";
 }
 
 TEST_F(LearningAgentTest, GetArchive)

--- a/test/learningAgentTest.cpp
+++ b/test/learningAgentTest.cpp
@@ -336,7 +336,8 @@ TEST_F(LearningAgentTest, TimedEvaluation)
         << "Should be a TimingSelectionMetrics as it is enabled";
     Selector::TimingSelectionMetrics* timedSelectionMetrics =
         static_cast<Selector::TimingSelectionMetrics*>(selectionMetrics);
-    ASSERT_GT(timedSelectionMetrics->getAgentTime(), 0) << "Agent execution time should be non null after training";
+    ASSERT_GT(timedSelectionMetrics->getAgentTime(), 0)
+        << "Agent execution time should be non null after training";
 }
 
 TEST_F(LearningAgentTest, GetArchive)

--- a/test/selectionMetricsTest.cpp
+++ b/test/selectionMetricsTest.cpp
@@ -6,6 +6,7 @@
 #include "learn/classificationLearningEnvironment.h"
 #include "selector/classificationSelectionMetrics.h"
 #include "selector/selectionMetrics.h"
+#include "selector/timingSelectionMetrics.h"
 
 #include <memory>
 
@@ -130,15 +131,24 @@ TEST(SelectionMetricsTest, WeightedSumAndTypeMismatch)
     // score = (1*2 + 3*3) / 5 = 11/5 = 2.2
     ASSERT_EQ(m1->getScore(), 2.2);
     // utility computed by implementation (note: uses updated score in formula)
-    // utility = (score * 2 + other.utility * 3) / 5 = (2.2*2 + 5*3)/5 = 19.4/5
-    // = 3.88
-    ASSERT_EQ(m1->getUtility(), 3.88);
+    // utility = (utility * 2 + other.utility * 3) / 5 = (2*2 + 5*3)/5 = 19/5
+    // = 3.8
+    ASSERT_EQ(m1->getUtility(), 3.8);
 
     // Type mismatch should throw
     auto classMetrics =
         std::make_shared<Selector::ClassificationSelectionMetrics>(
             std::vector<double>{1.0}, std::vector<size_t>{1});
     ASSERT_THROW(m1->weightedSum(classMetrics, 1, 1), std::runtime_error);
+}
+
+TEST(SelectionMetricsTest, Comparison)
+{
+    auto m1 = std::make_shared<Selector::SelectionMetrics>(3.0, 2.0);
+    auto m2 = std::make_shared<Selector::SelectionMetrics>(1.0, 5.0);
+
+    ASSERT_FALSE(m1 < m2);
+    ASSERT_TRUE(m2 < m1);
 }
 
 TEST(ClassificationSelectionMetricsTest, Constructor)
@@ -237,4 +247,90 @@ TEST(ClassificationSelectionMetricsTest, InitAndExtractEpisode)
 
     ASSERT_EQ(metrics.getNbEvalPerClassPerClass().at(0), 3);
     ASSERT_EQ(metrics.getNbEvalPerClassPerClass().at(1), 3);
+}
+
+TEST(TimingSelectionMetricsTest, DefaultAndParamConstructor)
+{
+    // Default constructor
+    auto defaultMetrics = std::make_shared<Selector::SelectionMetrics>();
+    auto defaultTimingMetrics =
+        std::make_shared<Selector::TimingSelectionMetrics>(defaultMetrics);
+
+    ASSERT_DOUBLE_EQ(defaultTimingMetrics->getScore(), 0.0);
+    ASSERT_DOUBLE_EQ(defaultTimingMetrics->getUtility(), 0.0);
+    ASSERT_DOUBLE_EQ(defaultTimingMetrics->getAgentTime(), 0.0);
+    ASSERT_DOUBLE_EQ(defaultTimingMetrics->getLeTime(), 0.0);
+    ASSERT_EQ(defaultTimingMetrics->getNbActions(), 0);
+
+    // Param constructor
+    auto paramMetrics = std::make_shared<Selector::SelectionMetrics>(1.5, 2.5);
+    auto paramTimingMetrics =
+        std::make_shared<Selector::TimingSelectionMetrics>(paramMetrics);
+
+    ASSERT_DOUBLE_EQ(paramTimingMetrics->getScore(), 1.5);
+    ASSERT_DOUBLE_EQ(paramTimingMetrics->getUtility(), 2.5);
+}
+
+TEST(TimingSelectionMetricsTest, ExtractMetricsEpisodeAddsScoreAndUtility)
+{
+    auto metrics = std::make_shared<Selector::SelectionMetrics>(1.5, 2.5);
+    auto timingMetrics =
+        std::make_shared<Selector::TimingSelectionMetrics>(metrics);
+    FakedLearningEnvironment env(3.0, 1.0);
+
+    // Call extraction
+    timingMetrics->extractMetricsEpisode(nullptr, 5, env, 12.2, 11.1);
+
+    // score and utility should be incremented
+    ASSERT_DOUBLE_EQ(timingMetrics->getScore(), 4.5);
+    ASSERT_DOUBLE_EQ(timingMetrics->getUtility(), 3.5);
+    ASSERT_DOUBLE_EQ(timingMetrics->getAgentTime(), 12.2);
+    ASSERT_DOUBLE_EQ(timingMetrics->getLeTime(), 11.1);
+    ASSERT_EQ(timingMetrics->getNbActions(), 5);
+}
+
+TEST(TimingSelectionMetricsTest, WeightedSumAndTypeMismatch)
+{
+    auto m1 = std::make_shared<Selector::SelectionMetrics>();
+    auto m2 = std::make_shared<Selector::SelectionMetrics>();
+    auto tm1 = std::make_shared<Selector::TimingSelectionMetrics>(m1);
+    auto tm2 = std::make_shared<Selector::TimingSelectionMetrics>(m2);
+    FakedLearningEnvironment env1(1.0, 3.0);
+    FakedLearningEnvironment env2(3.0, 7.0);
+
+    // Call extraction
+    tm1->extractMetricsEpisode(nullptr, 5, env1, 10, 20);
+    tm2->extractMetricsEpisode(nullptr, 15, env2, 29, 10);
+
+    // weighted sum
+    ASSERT_NO_THROW(
+        tm1->weightedSum(tm2, tm1->getNbActions(), tm2->getNbActions()));
+    // score = (1.0*5 + 3*15) / (5+15) = 50/20 = 2.5
+    ASSERT_DOUBLE_EQ(tm1->getScore(), 2.5);
+    // utility = (3.0*5 + 7.0*15) / (5+15) = 120/20 = 6
+    ASSERT_DOUBLE_EQ(tm1->getUtility(), 6);
+    // agentTime = (10*5 + 29*15) / (5+15) = 485/20 = 24.25
+    ASSERT_DOUBLE_EQ(tm1->getAgentTime(), 24.25);
+    // leTime = (20*5 + 8*15) / (5+15) = 220/20 = 11
+    ASSERT_DOUBLE_EQ(tm1->getLeTime(), 12.5);
+    // nbActions (5*5+15*15) / (5+15) = 250/20 = 12
+    ASSERT_EQ(tm1->getNbActions(), 12);
+
+    // Type mismatch should throw
+    ASSERT_THROW(tm1->weightedSum(m1, 1, 1), std::runtime_error);
+}
+
+TEST(TimingSelectionMetricsTest, Comparison)
+{
+    auto m1 = std::make_shared<Selector::SelectionMetrics>(3.0, 2.0);
+    auto m2 = std::make_shared<Selector::SelectionMetrics>(1.0, 5.0);
+    auto tm1 = std::make_shared<Selector::TimingSelectionMetrics>(m1);
+    auto tm2 = std::make_shared<Selector::TimingSelectionMetrics>(m2);
+
+    ASSERT_TRUE(tm2 < tm1);
+    ASSERT_FALSE(tm1 < tm2);
+    ASSERT_TRUE(m2 < tm1);
+    ASSERT_FALSE(tm1 < m2);
+    ASSERT_TRUE(tm2 < m1);
+    ASSERT_FALSE(m1 < tm2);
 }

--- a/test/selectionMetricsTest.cpp
+++ b/test/selectionMetricsTest.cpp
@@ -279,7 +279,7 @@ TEST(TimingSelectionMetricsTest, ExtractMetricsEpisodeAddsScoreAndUtility)
     FakedLearningEnvironment env(3.0, 1.0);
 
     // Call extraction
-    timingMetrics->extractMetricsEpisode(nullptr, 5, env, 12.2, 11.1);
+    timingMetrics->extractMetricsEpisodeWithTiming(nullptr, 5, env, 12.2, 11.1);
 
     // score and utility should be incremented
     ASSERT_DOUBLE_EQ(timingMetrics->getScore(), 4.5);
@@ -299,8 +299,8 @@ TEST(TimingSelectionMetricsTest, WeightedSumAndTypeMismatch)
     FakedLearningEnvironment env2(3.0, 7.0);
 
     // Call extraction
-    tm1->extractMetricsEpisode(nullptr, 5, env1, 10, 20);
-    tm2->extractMetricsEpisode(nullptr, 15, env2, 29, 10);
+    tm1->extractMetricsEpisodeWithTiming(nullptr, 5, env1, 10, 20);
+    tm2->extractMetricsEpisodeWithTiming(nullptr, 15, env2, 29, 10);
 
     // weighted sum
     ASSERT_NO_THROW(


### PR DESCRIPTION
Add differentiated timing measurement for agent and environment.

Implemented in learning agent, with parameter to enable it in parameter file.